### PR TITLE
Rename config values and refactor code to align with new config

### DIFF
--- a/src/Commands/ImportCommand.php
+++ b/src/Commands/ImportCommand.php
@@ -12,6 +12,7 @@ use Psr\Container\ContainerInterface;
 use Vanilla\KnowledgePorter\Destinations\AbstractDestination;
 use Vanilla\KnowledgePorter\Main;
 use Vanilla\KnowledgePorter\Sources\AbstractSource;
+use Garden\Schema\Schema;
 
 /**
  * Class ImportCommand
@@ -87,7 +88,9 @@ class ImportCommand extends AbstractCommand {
         /* @var \Vanilla\KnowledgePorter\Sources\AbstractSource $source */
         $source = $this->container->get($sourceClass);
         $source->setDestination($dest);
-        $source->setConfig($this->config['source']);
+        $sourceConfig = $this->config['source'];
+        $sourceConfig['targetDomain'] = $this->config['destination']['domain'] ?? null;
+        $source->setConfig($sourceConfig);
         return $source;
     }
 }

--- a/src/Destinations/VanillaDestination.php
+++ b/src/Destinations/VanillaDestination.php
@@ -178,6 +178,9 @@ class VanillaDestination extends AbstractDestination {
      */
     public function setConfig(array $config): void {
         $this->config = $config;
+        $domain = $this->config['domain'] ?? null;
+        $domain = "http://$domain";
+
         if ($config['api']['cache'] ?? true) {
             $this->vanillaApi->addMiddleware($this->container->get(HttpCacheMiddleware::class));
         }
@@ -185,7 +188,7 @@ class VanillaDestination extends AbstractDestination {
             $this->vanillaApi->addMiddleware($this->container->get(HttpLogMiddleware::class));
         }
         $this->vanillaApi->setToken($this->config['token']);
-        $this->vanillaApi->setBaseUrl($this->config['baseUrl']);
+        $this->vanillaApi->setBaseUrl($domain);
     }
 
     /**

--- a/src/HttpClients/ZendeskClient.php
+++ b/src/HttpClients/ZendeskClient.php
@@ -50,7 +50,7 @@ class ZendeskClient extends HttpClient {
      */
     public function getCategories(string $locale, array $query = []): iterable {
         $queryParams = empty($query) ? '' : '?'.http_build_query($query);
-        $results = $this->get("/help_center/$locale/categories.json".$queryParams)->getBody();
+        $results = $this->get("/api/v2/help_center/$locale/categories.json".$queryParams)->getBody();
         $zendeskCategories = $results['categories'] ?? null;
 
         foreach ($zendeskCategories as &$zendeskCategory) {
@@ -73,7 +73,7 @@ class ZendeskClient extends HttpClient {
      */
     public function getSections(string $locale, array $query = []): array {
         $queryParams = empty($query) ? '' : '?'.http_build_query($query);
-        $results = $this->get("/help_center/$locale/sections.json".$queryParams)->getBody();
+        $results = $this->get("/api/v2/help_center/$locale/sections.json".$queryParams)->getBody();
 
         return $results['sections'] ?? [];
     }
@@ -87,7 +87,7 @@ class ZendeskClient extends HttpClient {
      */
     public function getArticles(string $locale, array $query = []): iterable {
         $queryParams = empty($query) ? '' : '?'.http_build_query($query);
-        $results = $this->get("/help_center/$locale/articles.json".$queryParams)->getBody();
+        $results = $this->get("/api/v2/help_center/$locale/articles.json".$queryParams)->getBody();
 
         foreach ($results['articles'] as &$article) {
             $article['format'] = 'wysiwyg';

--- a/src/Sources/VanillaSource.php
+++ b/src/Sources/VanillaSource.php
@@ -99,7 +99,7 @@ class VanillaSource extends AbstractSource {
      * @return string
      */
     protected function addPrefix($str): string {
-        $newStr = $this->config["prefix"].$str;
+        $newStr = $this->config["foreignIDPrefix"].$str;
         return $newStr;
     }
 
@@ -110,7 +110,7 @@ class VanillaSource extends AbstractSource {
      * @return string
      */
     protected function knowledgeCategorySmartId($str): string {
-        $newStr = '$foreignID:'.$this->config["prefix"].$str;
+        $newStr = '$foreignID:'.$this->config["foreignIDPrefix"].$str;
         return $newStr;
     }
 
@@ -122,7 +122,7 @@ class VanillaSource extends AbstractSource {
      */
     protected function calculateParentID($str): string {
         if ($str != "-1") {
-            $newStr = '$foreignID:' . $this->config["prefix"] . $str;
+            $newStr = '$foreignID:' . $this->config["foreignIDPrefix"] . $str;
         } else {
             $newStr = $str;
         }
@@ -182,7 +182,7 @@ class VanillaSource extends AbstractSource {
      * @return string
      */
     protected function knowledgeBaseSmartId($str): string {
-        $newStr = '$foreignID:'.$this->config["prefix"].$str;
+        $newStr = '$foreignID:'.$this->config["foreignIDPrefix"].$str;
         return $newStr;
     }
 


### PR DESCRIPTION
Changes to the config requested in https://github.com/vanilla/knowledge/issues/1664

new sample config:

```
{
    "source": {
        "type": "zendesk",
        "foreignIDPrefix": "zd-raccoon",
        "domain": "raccoonworks.zendesk.com",
        "token": "",
        "sourceLocale": "en-us",
        "import": {
            "categories": false,
            "sections": false,
            "articles": true
        },
        "pageLimit": 10,
        "pageFrom": 1,
        "pageTo": 10
    },
    "destination": {
        "type": "vanilla",
        "domain": "dev.vanilla.localhost",
        "token": "",
        "update": "always"
    }
}

```