### PR TITLE
Add Zendesk rate limit middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 ./tests/mocks/*
+/tests/cache/

--- a/src/Destinations/AbstractDestination.php
+++ b/src/Destinations/AbstractDestination.php
@@ -10,13 +10,15 @@ namespace Vanilla\KnowledgePorter\Destinations;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Vanilla\KnowledgePorter\ConfigurableTrait;
+use Vanilla\KnowledgePorter\TaskLoggerAwareInterface;
+use Vanilla\KnowledgePorter\TaskLoggerAwareTrait;
 
 /**
  * Class AbstractDestination
  * @package Vanilla\KnowledgePorter\Destinations
  */
-abstract class AbstractDestination implements LoggerAwareInterface {
-    use ConfigurableTrait, LoggerAwareTrait;
+abstract class AbstractDestination implements TaskLoggerAwareInterface {
+    use ConfigurableTrait, TaskLoggerAwareTrait;
 
     /**
      * Import knowledge bases from source to destination.

--- a/src/HttpClients/HttpRateLimitMiddleware.php
+++ b/src/HttpClients/HttpRateLimitMiddleware.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+namespace Vanilla\KnowledgePorter\HttpClients;
+
+use Garden\Http\HttpRequest;
+use Garden\Http\HttpResponse;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+
+/**
+ * A middleware that will handle API rate limits for ZenDesk and retry after the cooldown period.
+ */
+class HttpRateLimitMiddleware implements LoggerAwareInterface {
+    use LoggerAwareTrait;
+
+    /**
+     * Call the next resolver, but handle API rate limits.
+     *
+     * @param HttpRequest $request
+     * @param callable $next
+     * @return HttpResponse
+     */
+    public function __invoke(HttpRequest $request, callable $next): HttpResponse {
+        /** @var HttpResponse $response */
+        $response = $next($request);
+
+
+        if ($response->getStatusCode() === 429 && $response->hasHeader('Retry-After')) {
+            $sleep = (int)$response->getHeader('Retry-After') + 1;
+            $this->logger->info("Rate limit reached, sleeping for {sleep} second(s).", ['sleep' => $sleep]);
+            sleep(max($sleep, 1));
+            $response = $next($request);
+        }
+        return $response;
+    }
+}

--- a/src/Main.php
+++ b/src/Main.php
@@ -16,6 +16,7 @@ use Psr\Log\LoggerInterface;
 use Vanilla\KnowledgePorter\Commands\AbstractCommand;
 use Vanilla\KnowledgePorter\HttpClients\HttpCacheMiddleware;
 use Vanilla\KnowledgePorter\HttpClients\HttpLogMiddleware;
+use Vanilla\KnowledgePorter\HttpClients\HttpRateLimitMiddleware;
 use Vanilla\KnowledgePorter\HttpClients\VanillaClient;
 use Vanilla\KnowledgePorter\HttpClients\ZendeskClient;
 
@@ -114,8 +115,11 @@ final class Main {
             ->setShared(true)
 
             ->rule(\Psr\Log\LoggerAwareInterface::class)
-            ->addCall('setLogger');
+            ->addCall('setLogger')
 
+            ->rule(TaskLoggerAwareInterface::class)
+            ->addCall('setLogger')
+            ;
 
 
         $di
@@ -133,6 +137,7 @@ final class Main {
             ->setShared(true)
 
             ->rule(ZendeskClient::class)
+            ->addCall('addMiddleware', [new Reference(HttpRateLimitMiddleware::class)])
 //            ->addCall('addMiddleware', [new Reference(\Vanilla\Analyzer\HttpRetryMiddleware::class)])
             ->setShared(false)
 

--- a/src/Sources/ZendeskSource.php
+++ b/src/Sources/ZendeskSource.php
@@ -307,12 +307,13 @@ HTML;
         $domain = $this->config['domain'];
         $domain = "https://$domain";
 
-        if ($config['api']['cache'] ?? true) {
-            $this->zendesk->addMiddleware($this->container->get(HttpCacheMiddleware::class));
-        }
         if ($config['api']['log'] ?? true) {
             $this->zendesk->addMiddleware($this->container->get(HttpLogMiddleware::class));
         }
+        if ($config['api']['cache'] ?? true) {
+            $this->zendesk->addMiddleware($this->container->get(HttpCacheMiddleware::class));
+        }
+
         $this->zendesk->setToken($this->config['token']);
         $this->zendesk->setBaseUrl($domain);
     }

--- a/src/TaskLoggerAwareInterface.php
+++ b/src/TaskLoggerAwareInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+namespace Vanilla\KnowledgePorter;
+
+use Garden\Cli\TaskLogger;
+
+/**
+ * For classes that want to have a `TaskLogger` automatically set.
+ */
+interface TaskLoggerAwareInterface {
+    /**
+     * Set the logger.
+     *
+     * @param TaskLogger $logger
+     * @return mixed
+     */
+    public function setLogger(TaskLogger $logger);
+}

--- a/src/TaskLoggerAwareTrait.php
+++ b/src/TaskLoggerAwareTrait.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+namespace Vanilla\KnowledgePorter;
+
+use Garden\Cli\TaskLogger;
+
+/**
+ * Basic Implementation of LoggerAwareInterface.
+ */
+trait TaskLoggerAwareTrait {
+    /**
+     * The logger instance.
+     *
+     * @var TaskLogger
+     */
+    protected $logger;
+
+    /**
+     * Sets a logger.
+     *
+     * @param TaskLogger $logger
+     */
+    public function setLogger(TaskLogger $logger) {
+        $this->logger = $logger;
+    }
+}


### PR DESCRIPTION
This PR does the following:

1. Adds Zendesk rate limit middleware to sleep the Zendesk if their API limit it reached.
2. Re-orders the log and cache middleware so that API calls that hit the cache won’t log the API call.
3. Adds some useful logging for article imports.

Closes https://github.com/vanilla/knowledge/issues/1630