### PR TITLE
Output better validation errors from the VanillaClient

### DIFF
--- a/src/HttpClients/VanillaClient.php
+++ b/src/HttpClients/VanillaClient.php
@@ -122,7 +122,7 @@ class VanillaClient extends HttpClient {
      * @throws NotFoundException Throw not found exception when 404 status received.
      */
     public function handleErrorResponse(HttpResponse $response, $options = []) {
-        if ($response->getStatusCode() === 404 && $options['throw'] ?? $this->throwExceptions) {
+        if ($response->getStatusCode() === 404 && ($options['throw'] ?? $this->throwExceptions)) {
             throw new NotFoundException($response, $response['message'] ?? '');
         } elseif (is_array($response->getBody()) && !empty($response->getBody()['errors'])) {
             $message = $this->makeValidationMessage($response->getBody()['errors']);


### PR DESCRIPTION
Check to see if there is the validation error “errors” field and if so, change the exception message to give the actual validation exception.

Closes https://github.com/vanilla/knowledge/issues/1653