### PR TITLE
Implement translations for zendesk categories and sections

### DIFF
--- a/src/Destinations/AbstractDestination.php
+++ b/src/Destinations/AbstractDestination.php
@@ -25,14 +25,14 @@ abstract class AbstractDestination implements TaskLoggerAwareInterface {
      *
      * @param iterable $rows
      */
-    abstract public function importKnowledgeBases(iterable $rows): void;
+    abstract public function importKnowledgeBases(iterable $rows): iterable;
 
     /**
      * Import knowledge categories from source to destination.
      *
      * @param iterable $rows
      */
-    abstract public function importKnowledgeCategories(iterable $rows): void;
+    abstract public function importKnowledgeCategories(iterable $rows): iterable;
 
     /**
      * Import knowledge articles from source to destination.

--- a/src/HttpClients/VanillaClient.php
+++ b/src/HttpClients/VanillaClient.php
@@ -95,6 +95,22 @@ class VanillaClient extends HttpClient {
     }
 
     /**
+     * GET /api/v2/knowledge-categories/{knowledgeCategoryID} using smartID.
+     *
+     * @param array $query
+     * @return array
+     */
+    public function getKnowledgeBaseTranslation(array $query = []): array {
+        $query['validateLocale'] = $query['validateLocale'] ?? false;
+        $result = $this->get("/api/v2/translations/kb", $query);
+        $body = $result->getBody();
+        if (count($body) === 1) {
+            $body = $body[0];
+        }
+        return $body;
+    }
+
+    /**
      *  GET /api/v2/knowledge-articles/{articleID} using vanilla api.
      *
      * @param string $paramSmartID

--- a/src/HttpClients/ZendeskClient.php
+++ b/src/HttpClients/ZendeskClient.php
@@ -64,6 +64,30 @@ class ZendeskClient extends HttpClient {
     }
 
     /**
+     * Execute GET /help_center/categories/{id}/translations.json request against zendesk api.
+     *
+     * @param string|int $categoryID
+     * @return array
+     */
+    public function getCategoryTranslations($categoryID): iterable {
+        $results = $this->get('/api/v2/help_center/categories/'.$categoryID.'/translations.json')->getBody();
+        $zendeskCategoryTranslations = $results['translations'] ?? null;
+        return $zendeskCategoryTranslations;
+    }
+
+    /**
+     * Execute GET /help_center/sections/{id}/translations.json request against zendesk api.
+     *
+     * @param string|int $sectionID
+     * @return array
+     */
+    public function getSectionTranslations($sectionID): iterable {
+        $results = $this->get('/api/v2/help_center/sections/'.$sectionID.'/translations.json')->getBody();
+        $zendeskCategoryTranslations = $results['translations'] ?? null;
+        return $zendeskCategoryTranslations;
+    }
+
+    /**
      * Execute GET /help_center/$locale/sections.json request against zendesk api.
      *
      * @param string $locale
@@ -100,5 +124,4 @@ class ZendeskClient extends HttpClient {
     public function getToken(): string {
         return $this->token;
     }
-
 }

--- a/src/Sources/AbstractSource.php
+++ b/src/Sources/AbstractSource.php
@@ -74,12 +74,16 @@ abstract class AbstractSource implements LoggerAwareInterface {
             if (is_string($value)) {
                 $result[$key] = $row[$value];
             } elseif (is_array($value)) {
-                $column = $value['column'];
-                $rowValue = $row[$column];
-                if (isset($value['filter'])) {
-                    $rowValue = call_user_func($value['filter'], $rowValue, $row);
+                if (array_key_exists('placeholder', $value)) {
+                    $result[$key] = $value['placeholder'];
+                } else {
+                    $column = $value['column'];
+                    $rowValue = $row[$column];
+                    if (isset($value['filter'])) {
+                        $rowValue = call_user_func($value['filter'], $rowValue, $row);
+                    }
+                    $result[$key] = $rowValue;
                 }
-                $result[$key] = $rowValue;
             }
         }
         return $result;


### PR DESCRIPTION
**Note for developers:**
If you will test it with some real zendesk data, don't forget to enable locales required.
For example for our K customer you need to enable these locales:
``` 
$Configuration['EnabledLocales']['vf_fr'] = 'fr';
$Configuration['EnabledLocales']['vf_es'] = 'es';
$Configuration['EnabledLocales']['vf_ru'] = 'ru';
$Configuration['EnabledLocales']['vf_zh'] = 'zh';
$Configuration['EnabledLocales']['vf_zh_TW'] = 'zh_TW';
$Configuration['EnabledLocales']['vf_da'] = 'da';
$Configuration['EnabledLocales']['vf_de'] = 'de';
$Configuration['EnabledLocales']['vf_it'] = 'it';
$Configuration['EnabledLocales']['vf_ja'] = 'ja';
$Configuration['EnabledLocales']['vf_ko'] = 'ko';
$Configuration['EnabledLocales']['vf_pl'] = 'pl';
$Configuration['EnabledLocales']['vf_pt'] = 'pt';
$Configuration['EnabledLocales']['vf_pt_BR'] = 'pt_BR';
$Configuration['EnabledLocales']['vf_ro'] = 'ro';
$Configuration['EnabledLocales']['vf_tr'] = 'tr';
$Configuration['EnabledLocales']['vf_fi'] = 'fi';
$Configuration['EnabledLocales']['vf_id'] = 'id';
$Configuration['EnabledLocales']['vf_sv'] = 'sv';
$Configuration['EnabledLocales']['vf_vi'] = 'vi';
$Configuration['EnabledLocales']['vf_th'] = 'th';
$Configuration['EnabledLocales']['vf_nl'] = 'nl';
$Configuration['EnabledLocales']['vf_no'] = 'no';
```


Closes: https://github.com/vanilla/knowledge/issues/1650
Closes: https://github.com/vanilla/knowledge/issues/1633