### PR TITLE
Add new feature to destination config: patchKnowledgeBase

### DIFF
--- a/src/Destinations/VanillaDestination.php
+++ b/src/Destinations/VanillaDestination.php
@@ -286,11 +286,20 @@ class VanillaDestination extends AbstractDestination {
      * @return array Returns an array in the format: `['added' => int, 'updated' => int, 'skipped' => int]`.
      */
     private function importKnowledgeArticlesInternal(iterable $rows): iterable {
-        $added = $updated = $skipped = 0;
+        $added = $updated = $skipped = $deleted = $undeleted = 0;
 
         foreach ($rows as $row) {
             if (($row['skip'] ?? '') === 'true') {
-                $skipped++;
+                try {
+                    $existingArticle = $this->vanillaApi->getKnowledgeArticleBySmartID($row["foreignID"]);
+                    $article = $this->vanillaApi->patch(
+                        '/api/v2/articles/' . $existingArticle['articleID'] . '/status',
+                        ['status' => 'deleted']
+                    )->getBody();
+                    $deleted++;
+                } catch (NotFoundException $ex) {
+                    $skipped++;
+                }
                 continue;
             }
 
@@ -309,6 +318,13 @@ class VanillaDestination extends AbstractDestination {
                 try {
                     // This should probably grab from the edit endpoint because that's what you'll be comparing to.
                     $existingArticle = $this->vanillaApi->getKnowledgeArticleBySmartID($row["foreignID"]);
+                    if ($existingArticle['status'] === 'deleted') {
+                        $this->vanillaApi->patch(
+                            '/api/v2/articles/' . $existingArticle['articleID'] . '/status',
+                            ['status' => "published"]
+                        );
+                        $undeleted++;
+                    }
                     $patch = $this->updateFields($existingArticle, $row, self::ARTICLE_EDIT_FIELDS);
                     if (!empty($patch)) {
                         $article = $this->vanillaApi->patch('/api/v2/articles/' . $existingArticle['articleID'], $patch)->getBody();
@@ -325,8 +341,8 @@ class VanillaDestination extends AbstractDestination {
             yield $article ?? $existingArticle;
         }
         $this->logger->end(
-            "Done (added: {added}, updated: {updated}, skipped: {skipped})",
-            ['added' => $added, 'updated' => $updated, 'skipped' => $skipped]
+            "Done (added: {added}, updated: {updated}, skipped: {skipped}, deleted: {deleted}, undeleted: {undeleted})",
+            ['added' => $added, 'updated' => $updated, 'skipped' => $skipped, 'deleted' => $deleted, 'undeleted' => $undeleted]
         );
     }
 

--- a/src/Sources/ZendeskSource.php
+++ b/src/Sources/ZendeskSource.php
@@ -193,7 +193,7 @@ class ZendeskSource extends AbstractSource {
 
             $syncFrom = ($syncFrom >= $currentTime) ? false : $syncFrom;
             if ($syncFrom) {
-              $queryParams['start_time'] = $syncFrom;
+                $queryParams['start_time'] = $syncFrom;
             }
 
             $articles = $this->zendesk->getArticles($locale, $queryParams);
@@ -581,7 +581,7 @@ HTML;
 
     /**
      * Translations for Knowledge Categories.
-     * 
+     *
      * @param iterable $knowledgeCategories
      * @param bool $translate
      */


### PR DESCRIPTION
Add new feature to destination config: patchKnowledgeBase
and default it to `false` to avoid unnecessary knowledge base changes.

That is required to not update `url-slug` of KB in 1st place.

Check zendesk article special cases (draft, private) and delete/undelete article on vanilla destination accordingly if article exists already.

Closes: https://github.com/vanilla/knowledge/issues/1683