### PR TITLE
Import Recommended Articles (Promoted)

### DIFF
--- a/src/Sources/ZendeskSource.php
+++ b/src/Sources/ZendeskSource.php
@@ -208,6 +208,7 @@ class ZendeskSource extends AbstractSource {
                 'locale' => ['column' => 'locale', 'filter' => [$this, 'getSourceLocale']],
                 'name' => 'name',
                 'body' => ['column' => 'body', 'filter' => [$this, 'parseUrls']],
+                'featured' => ['column' => 'promoted'],
                 'alias' => ['column' => 'id', 'filter' => [$this, 'setAlias']],
                 'skip' => ['columns' => ['draft', 'user_segment_id'], 'filter' => [$this, 'setSkipStatus']],
                 'dateUpdated' => 'updated_at',


### PR DESCRIPTION
Import Recommended Articles from Zendesk which calls them promoted articles.  Updates had to be made to the get_edit schema to ensure the featured status is returned if we are patching articles.

required pr https://github.com/vanilla/knowledge/pull/1795
closes https://github.com/vanilla/knowledge-porter/issues/33