### PR TITLE
Add extra alias for Kayako articles with category id and article slug

### DIFF
--- a/src/Destinations/VanillaDestination.php
+++ b/src/Destinations/VanillaDestination.php
@@ -503,7 +503,10 @@ class VanillaDestination extends AbstractDestination {
                         $this->logRehostHeaders($response);
                         $article = $response->getBody();
                         if (!is_null($alias)) {
-                            $this->vanillaApi->put('/api/v2/articles/' . $article['articleID'] . '/aliases', ["aliases" => [$alias]]);
+                            if (!is_array($alias)) {
+                                $alias = [$alias];
+                            }
+                            $this->vanillaApi->put('/api/v2/articles/' . $article['articleID'] . '/aliases', ["aliases" => $alias]);
                         }
                         if (isset($row['featured']) && $row['featured']) {
                             $this->putFeaturedArticle($article['articleID'], $row['featured']);

--- a/src/Sources/KayakoXmlSource.php
+++ b/src/Sources/KayakoXmlSource.php
@@ -205,11 +205,16 @@ class KayakoXmlSource extends AbstractSource {
      * @return string
      * @todo Make sure to prefix with the prefix like: `<prefix>/<path>`. Hint: `parse_url()`.
      */
-    protected function setAlias($articleID): string {
+    protected function setAlias($articleID, array $row): array {
+        $aliases =[];
         $prefix = ($this->config["foreignIDPrefix"] !== '') ?  '/'.$this->config["foreignIDPrefix"] : '';
 
-        $basePath = "$prefix/index.php%3F/Knowledgebase/Article/View/$articleID";
-        return $basePath;
+        $aliases[] = "$prefix/index.php%3F/Knowledgebase/Article/View/$articleID";
+
+        $slug = str_replace([' ', '/'], '-', trim(strtolower($row['subject'])));
+        $slug = str_replace(['(', ')'], '', $slug);
+        $aliases[] = "$prefix/index.php%3F/Knowledgebase/Article/View/$articleID/{$row['categoryid']}/$slug";
+        return $aliases;
     }
 
     /**


### PR DESCRIPTION
Client feedback mentioned that [article](https://connect.meridianlink.com/LendingQB/kb/articles/2044-scheduled-02-09-18-update) which is kayako `articleid=894` has a broken link to not existing article `/kb/articles/aliases/m-/index.php?/Knowledgebase/Article/View/911/0/renovation-loans-user-guide-pilot-feature` which should be and aliased kayako `articleid=911`.

This PR add such pattern to aliases when we create Vanilla article aliases.
Now every article will autocreate 2 aliases when POSTed:

- /kb/articles/aliases/m-/index.php?/Knowledgebase/Article/View/{(ID}
- /kb/articles/aliases/m-/index.php?/Knowledgebase/Article/View/{(ID}/{CATEGORY_ID}/{SLUG}

Relates to: #53

