### PR TITLE
Fix issue when article fails to be created.

### DIFF
--- a/src/Sources/ZendeskSource.php
+++ b/src/Sources/ZendeskSource.php
@@ -236,6 +236,10 @@ class ZendeskSource extends AbstractSource {
             $translate = $this->config['import']['translations'] ?? false;
             foreach ($kbArticles as $kbArticle) {
                 if ($translate) {
+                    if (!$kbArticle) {
+                        $this->logger->error("Skipping foreign article translations because the article failed to be created.");
+                        continue;
+                    }
                     /** @var iterable $translation */
                     $translation = $this->zendesk->getArticleTranslations($this->trimPrefix($kbArticle['foreignID']));
                     $kbTranslations = $this->transform($translation, [


### PR DESCRIPTION
If an article failed to be created (or couldn't be yielded) all of the rest of the process would stop, failing the import.

(Example is the king import of jelly bubblewitch3 saga) with the following import parameters.

```
        "pageLimit": 10,
        "pageFrom": 88,
        "pageTo": 89,
```

One of those articles actually doesn't have a body, so fails our article validation.