### PR TITLE
Fix duplicate articles being posted

### DIFF
--- a/src/Destinations/VanillaDestination.php
+++ b/src/Destinations/VanillaDestination.php
@@ -571,11 +571,10 @@ class VanillaDestination extends AbstractDestination {
                         $skipped++;
                     }
                 } catch (HttpResponseException $ex) {
-                    if ($ex->getCode() == 409) {
+                    if ($ex->getCode() != 404) {
                         $this->logger->warning($ex->getMessage() . " failed to import article.");
                         continue;
                     }
-
                     if (!empty($row['userData'])) {
                         $user = $this->getOrCreateUser($row['userData']);
                         $row['updateUserID'] = $user['userID'];


### PR DESCRIPTION
When checking if an article exists we should receive a `404` error if it doesn't.  If we receive any other error then we should just  log it as an error importing the article and carry on.  

related https://github.com/vanilla/support/issues/3899