### PR TITLE
VNLA-2585: Fix Translation Duplicates

### DIFF
--- a/src/Destinations/VanillaDestination.php
+++ b/src/Destinations/VanillaDestination.php
@@ -7,8 +7,6 @@
 
 namespace Vanilla\KnowledgePorter\Destinations;
 
-use Exception;
-use Garden\Cli\TaskLogger;
 use Garden\Http\HttpResponse;
 use Garden\Http\HttpResponseException;
 use Garden\Schema\Schema;
@@ -20,7 +18,6 @@ use Vanilla\KnowledgePorter\HttpClients\HttpLogMiddleware;
 use Vanilla\KnowledgePorter\HttpClients\HttpVanillaCloudRateLimitBypassMiddleware;
 use Vanilla\KnowledgePorter\HttpClients\NotFoundException;
 use Vanilla\KnowledgePorter\HttpClients\VanillaClient;
-use Vanilla\KnowledgePorter\Utils\ApiPaginationIterator;
 
 /**
  * Class VanillaDestination


### PR DESCRIPTION
# Issue
Article translations were getting duplicated.

See: https://higherlogic.atlassian.net/browse/VNLA-2585

# Root cause
The API wasn't called properly.

# Changes
* Fix the API call. The rest of the changes are just Prettier doing its thing.

See: https://github.com/vanilla/knowledge-porter/pull/68/files#diff-c70da3928e0fba4f1b9207a6a2722ba3fa5a1e6938fbbf89e69e932ffb0eac2cR318-R322