### PR TITLE
VNLA-2785: Remove lock version on `psr/log`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "vanilla/garden-container": "^3.0",
         "vanilla/garden-schema": "~1.10.2",
         "vanilla/garden-http": "^2.1",
-        "psr/log": "^1.1",
+        "psr/log": "*",
         "psr/simple-cache": "^1.0",
         "symfony/cache": "^4.1",
         "ext-dom": "*",


### PR DESCRIPTION
# Issue

The lock on version `1.1` is causing issues with the Vanilla-service-queue. Removing it shouldn't cause any issues and will unblock the implementation of a job to execute the KB porter.