### PR TITLE
VNLA-2785: Remove lock version on `psr/lsimple-cache`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "vanilla/garden-schema": "~1.10.2",
         "vanilla/garden-http": "^2.1",
         "psr/log": "*",
-        "psr/simple-cache": "^1.0",
+        "psr/simple-cache": "*",
         "symfony/cache": "^4.1",
         "ext-dom": "*",
         "ext-mbstring": "*",


### PR DESCRIPTION
# Issue

The lock on version `1.0` is causing issues with the Vanilla-service-queue. Removing it shouldn't cause any issues and will unblock the implementation of a job to execute the KB porter.