### PR TITLE
VNLA-3506: Optimize kb porter for queue

### DIFF
--- a/src/Destinations/AbstractDestination.php
+++ b/src/Destinations/AbstractDestination.php
@@ -17,7 +17,8 @@ use Vanilla\KnowledgePorter\TaskLoggerAwareTrait;
  * Class AbstractDestination
  * @package Vanilla\KnowledgePorter\Destinations
  */
-abstract class AbstractDestination implements TaskLoggerAwareInterface {
+abstract class AbstractDestination implements TaskLoggerAwareInterface
+{
     use ConfigurableTrait, TaskLoggerAwareTrait;
 
     /** @var string[] */
@@ -26,7 +27,8 @@ abstract class AbstractDestination implements TaskLoggerAwareInterface {
     /**
      * @param string[] $rehostHeaders
      */
-    public function setRehostHeaders(array $rehostHeaders): void {
+    public function setRehostHeaders(array $rehostHeaders): void
+    {
         $this->rehostHeaders = $rehostHeaders;
     }
 
@@ -49,7 +51,9 @@ abstract class AbstractDestination implements TaskLoggerAwareInterface {
      *
      * @param iterable $rows
      */
-    abstract public function importKnowledgeCategories(iterable $rows): iterable;
+    abstract public function importKnowledgeCategories(
+        iterable $rows
+    ): iterable;
 
     /**
      * Import knowledge articles from source to destination.
@@ -63,7 +67,9 @@ abstract class AbstractDestination implements TaskLoggerAwareInterface {
      * @param string $foreignID
      * @return array
      */
-    abstract public function getKnowledgeBaseBySmartID(string $foreignID): array;
+    abstract public function getKnowledgeBaseBySmartID(
+        string $foreignID
+    ): array;
 
     /**
      * Delete archived articles.
@@ -72,6 +78,45 @@ abstract class AbstractDestination implements TaskLoggerAwareInterface {
      * @param array $articles
      * @param string $prefix
      */
-    abstract public function deleteArchivedArticles(array $knowledgeBases, array $articles, string $prefix);
+    abstract public function deleteArchivedArticles(
+        array $knowledgeBases,
+        array $articles,
+        string $prefix
+    );
 
+    /**
+     * Synchronize foreign Knowledge Bases with the one from the destination.
+     *
+     * @param array $foreignKnowledgeBaseIDs
+     * @param array $query
+     * @return mixed
+     */
+    abstract public function syncKnowledgeBase(
+        array $foreignKnowledgeBaseIDs,
+        array $query = []
+    ): array;
+
+    /**
+     * Synchronize foreign Knowledge Categories with the one from the destination.
+     *
+     * @param array $foreignKnowledgeCategoryIDs
+     * @param array $query
+     * @return array
+     */
+    abstract public function syncKnowledgeCategories(
+        array $foreignKnowledgeCategoryIDs,
+        array $query = []
+    ): array;
+
+    /**
+     * Synchronize foreign articles with the one from the destination.
+     *
+     * @param array $foreignArticleIDs
+     * @param array $query
+     * @return array
+     */
+    abstract public function syncArticles(
+        array $foreignArticleIDs,
+        array $query = []
+    ): array;
 }

--- a/src/Destinations/AbstractDestination.php
+++ b/src/Destinations/AbstractDestination.php
@@ -21,8 +21,6 @@ abstract class AbstractDestination implements TaskLoggerAwareInterface
 {
     use ConfigurableTrait, TaskLoggerAwareTrait;
 
-    const NO_DATA = -1;
-
     /** @var string[] */
     protected $rehostHeaders = [];
 
@@ -91,34 +89,34 @@ abstract class AbstractDestination implements TaskLoggerAwareInterface
      *
      * @param array $foreignKnowledgeBaseIDs
      * @param array $query
-     * @return array|int
+     * @return array
      */
     abstract public function syncKnowledgeBase(
         array $foreignKnowledgeBaseIDs,
         array $query = []
-    );
+    ): array;
 
     /**
      * Synchronize foreign Knowledge Categories with the one from the destination.
      *
      * @param array $foreignKnowledgeCategoryIDs
      * @param array $query
-     * @return array|int
+     * @return array
      */
     abstract public function syncKnowledgeCategories(
         array $foreignKnowledgeCategoryIDs,
         array $query = []
-    );
+    ): array;
 
     /**
      * Synchronize foreign articles with the one from the destination.
      *
      * @param array $foreignArticleIDs
      * @param array $query
-     * @return array|int
+     * @return array
      */
     abstract public function syncArticles(
         array $foreignArticleIDs,
         array $query = []
-    );
+    ): array;
 }

--- a/src/Destinations/AbstractDestination.php
+++ b/src/Destinations/AbstractDestination.php
@@ -17,8 +17,7 @@ use Vanilla\KnowledgePorter\TaskLoggerAwareTrait;
  * Class AbstractDestination
  * @package Vanilla\KnowledgePorter\Destinations
  */
-abstract class AbstractDestination implements TaskLoggerAwareInterface
-{
+abstract class AbstractDestination implements TaskLoggerAwareInterface {
     use ConfigurableTrait, TaskLoggerAwareTrait;
 
     /** @var string[] */
@@ -27,8 +26,7 @@ abstract class AbstractDestination implements TaskLoggerAwareInterface
     /**
      * @param string[] $rehostHeaders
      */
-    public function setRehostHeaders(array $rehostHeaders): void
-    {
+    public function setRehostHeaders(array $rehostHeaders): void {
         $this->rehostHeaders = $rehostHeaders;
     }
 
@@ -51,9 +49,7 @@ abstract class AbstractDestination implements TaskLoggerAwareInterface
      *
      * @param iterable $rows
      */
-    abstract public function importKnowledgeCategories(
-        iterable $rows
-    ): iterable;
+    abstract public function importKnowledgeCategories(iterable $rows): iterable;
 
     /**
      * Import knowledge articles from source to destination.
@@ -67,9 +63,7 @@ abstract class AbstractDestination implements TaskLoggerAwareInterface
      * @param string $foreignID
      * @return array
      */
-    abstract public function getKnowledgeBaseBySmartID(
-        string $foreignID
-    ): array;
+    abstract public function getKnowledgeBaseBySmartID(string $foreignID): array;
 
     /**
      * Delete archived articles.
@@ -78,11 +72,7 @@ abstract class AbstractDestination implements TaskLoggerAwareInterface
      * @param array $articles
      * @param string $prefix
      */
-    abstract public function deleteArchivedArticles(
-        array $knowledgeBases,
-        array $articles,
-        string $prefix
-    );
+    abstract public function deleteArchivedArticles(array $knowledgeBases, array $articles, string $prefix);
 
     /**
      * Synchronize foreign Knowledge Bases with the one from the destination.

--- a/src/Destinations/AbstractDestination.php
+++ b/src/Destinations/AbstractDestination.php
@@ -21,6 +21,8 @@ abstract class AbstractDestination implements TaskLoggerAwareInterface
 {
     use ConfigurableTrait, TaskLoggerAwareTrait;
 
+    const NO_DATA = -1;
+
     /** @var string[] */
     protected $rehostHeaders = [];
 
@@ -89,34 +91,34 @@ abstract class AbstractDestination implements TaskLoggerAwareInterface
      *
      * @param array $foreignKnowledgeBaseIDs
      * @param array $query
-     * @return mixed
+     * @return array|int
      */
     abstract public function syncKnowledgeBase(
         array $foreignKnowledgeBaseIDs,
         array $query = []
-    ): array;
+    );
 
     /**
      * Synchronize foreign Knowledge Categories with the one from the destination.
      *
      * @param array $foreignKnowledgeCategoryIDs
      * @param array $query
-     * @return array
+     * @return array|int
      */
     abstract public function syncKnowledgeCategories(
         array $foreignKnowledgeCategoryIDs,
         array $query = []
-    ): array;
+    );
 
     /**
      * Synchronize foreign articles with the one from the destination.
      *
      * @param array $foreignArticleIDs
      * @param array $query
-     * @return array
+     * @return array|int
      */
     abstract public function syncArticles(
         array $foreignArticleIDs,
         array $query = []
-    ): array;
+    );
 }

--- a/src/Destinations/VanillaDestination.php
+++ b/src/Destinations/VanillaDestination.php
@@ -1236,6 +1236,9 @@ class VanillaDestination extends AbstractDestination
             if (
                 in_array($knowledgeBase["foreignID"], $foreignKnowledgeBaseIDs)
             ) {
+                $this->logger->info(
+                    "Syncing knowledge base {$knowledgeBase["knowledgeBaseID"]} matches the foreign}."
+                );
                 $result[] = $knowledgeBase["knowledgeBaseID"];
             }
         }
@@ -1256,7 +1259,12 @@ class VanillaDestination extends AbstractDestination
         );
 
         foreach ($knowledgeCategories as $knowledgeCategory) {
+            $this->logger->info(
+                "Syncing knowledge category {$knowledgeCategory["knowledgeCategoryID"]}."
+            );
+
             if (
+                $knowledgeCategory["parentID"] > 0 &&
                 !in_array(
                     $knowledgeCategory["foreignID"],
                     $foreignKnowledgeCategoryIDs
@@ -1265,19 +1273,17 @@ class VanillaDestination extends AbstractDestination
                 $this->logger->info(
                     "Deleting knowledge category {$knowledgeCategory["knowledgeCategoryID"]} because it no longer exists on the source."
                 );
-                $response = $this->vanillaApi->delete(
-                    "/api/v2/knowledge-categories/{$knowledgeCategory["knowledgeCategoryID"]}"
-                );
-
-                if (!$response->isSuccessful()) {
-                    $this->logger->error(
-                        "Failed deleting knowledge category with ID {$knowledgeCategory["knowledgeCategoryID"]}."
+                try {
+                    $response = $this->vanillaApi->delete(
+                        "/api/v2/knowledge-categories/{$knowledgeCategory["knowledgeCategoryID"]}"
                     );
-                } else {
                     $result[] = $knowledgeCategory["knowledgeCategoryID"];
+                } catch (HttpResponseException $e) {
+                    $this->logger->error($e->getMessage());
                 }
             }
         }
+        
         return $result;
     }
 

--- a/src/Destinations/VanillaDestination.php
+++ b/src/Destinations/VanillaDestination.php
@@ -1229,13 +1229,10 @@ class VanillaDestination extends AbstractDestination
     public function syncKnowledgeBase(
         array $foreignKnowledgeBaseIDs,
         array $query = []
-    ) {
+    ): array
+    {
         $matched = $skipped = [];
         $knowledgeBases = $this->vanillaApi->getKnowledgeBases($query);
-
-        if(empty($knowledgeBases)) {
-            return self::NO_DATA;
-        }
 
         foreach ($knowledgeBases as $knowledgeBase) {
             if (
@@ -1251,7 +1248,7 @@ class VanillaDestination extends AbstractDestination
         $matchedCount = count($matched);
         $skippedCount = count($skipped);
         $this->logger->info("Synced $processedCount articles (matched: $matchedCount, skipped: $skippedCount)");
-        return $matched;
+        return ["fetched" => $processedCount , "vanillaIDs" => $matched];
     }
 
     /**
@@ -1260,15 +1257,12 @@ class VanillaDestination extends AbstractDestination
     public function syncKnowledgeCategories(
         array $foreignKnowledgeCategoryIDs,
         array $query = []
-    ) {
+    ): array
+    {
         $matched = $deleted = $skipped = $failed = [];
         $knowledgeCategories = $this->vanillaApi->getKnowledgeCategories(
             $query
         );
-
-        if(empty($knowledgeCategories)) {
-            return self::NO_DATA;
-        }
 
         foreach ($knowledgeCategories as $knowledgeCategory) {
             if ($knowledgeCategory["parentID"] < 1) {
@@ -1297,7 +1291,7 @@ class VanillaDestination extends AbstractDestination
         $skippedCount = count($skipped);
         $failedCount = count($failed);
         $this->logger->info("Synced $processedCount articles (matched: $matchedCount, deleted: $deletedCount, skipped: $skippedCount, failed: $failedCount)");
-        return $matched;
+        return ["fetched" => $processedCount , "vanillaIDs" => $matched];
     }
 
     /**
@@ -1306,17 +1300,14 @@ class VanillaDestination extends AbstractDestination
     public function syncArticles(
         array $foreignArticleIDs,
         array $query = []
-    ) {
+    ): array
+    {
         $matched = $deleted = $failed = [];
         $articles = $this->vanillaApi->getArticles($query);
 
-        if(empty($articles)) {
-            return self::NO_DATA;
-        }
-
         foreach ($articles as $article) {
             if (in_array($article["foreignID"], $foreignArticleIDs)) {
-                $matched[] = $article["foreignID"];
+                $matched[] = $article["articleID"];
             } else {
                 $this->logger->debug(
                     "Deleting article {$article["articleID"]} because it no longer exists on the source."
@@ -1343,6 +1334,6 @@ class VanillaDestination extends AbstractDestination
         $deletedCount = count($deleted);
         $failedCount = count($failed);
         $this->logger->info("Synced $processedCount articles (matched: $matchedCount, deleted: $deletedCount, failed: $failedCount)");
-        return $matched;
+        return ["fetched" => $processedCount , "vanillaIDs" => $matched];
     }
 }

--- a/src/Destinations/VanillaDestination.php
+++ b/src/Destinations/VanillaDestination.php
@@ -11,7 +11,6 @@ use Garden\Http\HttpResponse;
 use Garden\Http\HttpResponseException;
 use Garden\Schema\Schema;
 use Garden\Schema\ValidationException;
-use Illuminate\Support\Facades\Log;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LogLevel;
 use Vanilla\KnowledgePorter\HttpClients\HttpCacheMiddleware;

--- a/src/Destinations/VanillaDestination.php
+++ b/src/Destinations/VanillaDestination.php
@@ -1247,7 +1247,7 @@ class VanillaDestination extends AbstractDestination
         $processedCount = count($knowledgeBases);
         $matchedCount = count($matched);
         $skippedCount = count($skipped);
-        $this->logger->info("Synced $processedCount articles (matched: $matchedCount, skipped: $skippedCount)");
+        $this->logger->info("Synced $processedCount articles (matched: $matchedCount, skipped: $skippedCount).");
         return ["fetched" => $processedCount , "vanillaIDs" => $matched];
     }
 
@@ -1290,7 +1290,7 @@ class VanillaDestination extends AbstractDestination
         $deletedCount = count($deleted);
         $skippedCount = count($skipped);
         $failedCount = count($failed);
-        $this->logger->info("Synced $processedCount articles (matched: $matchedCount, deleted: $deletedCount, skipped: $skippedCount, failed: $failedCount)");
+        $this->logger->info("Synced $processedCount articles (matched: $matchedCount, deleted: $deletedCount, skipped: $skippedCount, failed: $failedCount).");
         return ["fetched" => $processedCount , "vanillaIDs" => $matched];
     }
 
@@ -1333,7 +1333,7 @@ class VanillaDestination extends AbstractDestination
         $matchedCount = count($matched);
         $deletedCount = count($deleted);
         $failedCount = count($failed);
-        $this->logger->info("Synced $processedCount articles (matched: $matchedCount, deleted: $deletedCount, failed: $failedCount)");
+        $this->logger->info("Synced $processedCount articles (matched: $matchedCount, deleted: $deletedCount, failed: $failedCount).");
         return ["fetched" => $processedCount , "vanillaIDs" => $matched];
     }
 }

--- a/src/Destinations/VanillaDestination.php
+++ b/src/Destinations/VanillaDestination.php
@@ -1246,14 +1246,11 @@ class VanillaDestination extends AbstractDestination
                 $skipped[] = $knowledgeBase["knowledgeBaseID"];
             }
         }
-        $this->logger->end(
-            "Synced {processed} knowledge bases (matched: {matched}, skipped: {skipped}).",
-            [
-                "processed" => count($knowledgeBases),
-                "matched" => count($matched),
-                "skipped" => count($skipped)
-            ]
-        );
+
+        $processedCount = count($knowledgeBases);
+        $matchedCount = count($matched);
+        $skippedCount = count($skipped);
+        $this->logger->info("Synced $processedCount articles (matched: $matchedCount, skipped: $skippedCount)");
         return $matched;
     }
 
@@ -1264,8 +1261,7 @@ class VanillaDestination extends AbstractDestination
         array $foreignKnowledgeCategoryIDs,
         array $query = []
     ) {
-        $processed = $matched = $deleted = $skipped = $failed = [];
-
+        $matched = $deleted = $skipped = $failed = [];
         $knowledgeCategories = $this->vanillaApi->getKnowledgeCategories(
             $query
         );
@@ -1275,7 +1271,6 @@ class VanillaDestination extends AbstractDestination
         }
 
         foreach ($knowledgeCategories as $knowledgeCategory) {
-            $processed[] = $knowledgeCategory["knowledgeCategoryID"];
             if ($knowledgeCategory["parentID"] < 1) {
                 $skipped[] = $knowledgeCategory["foreignID"];
             } elseif (in_array($knowledgeCategory["foreignID"], $foreignKnowledgeCategoryIDs)) {
@@ -1296,17 +1291,13 @@ class VanillaDestination extends AbstractDestination
             }
         }
 
-        $this->logger->end(
-            "Synced {processed} articles (matched: {matched}, deleted: {deleted}, skipped: {skipped}, failed: {failed})",
-            [
-                "processed" => count($processed),
-                "matched" => count($matched),
-                "deleted" => count($deleted),
-                "skipped" => count($skipped),
-                "failed" => count($failed),
-            ]
-        );
-        return $knowledgeCategories;
+        $processedCount = count($knowledgeCategories);
+        $matchedCount = count($matched);
+        $deletedCount = count($deleted);
+        $skippedCount = count($skipped);
+        $failedCount = count($failed);
+        $this->logger->info("Synced $processedCount articles (matched: $matchedCount, deleted: $deletedCount, skipped: $skippedCount, failed: $failedCount)");
+        return $matched;
     }
 
     /**
@@ -1316,7 +1307,7 @@ class VanillaDestination extends AbstractDestination
         array $foreignArticleIDs,
         array $query = []
     ) {
-        $processed = $matched = $deleted = $failed = [];
+        $matched = $deleted = $failed = [];
         $articles = $this->vanillaApi->getArticles($query);
 
         if(empty($articles)) {
@@ -1324,7 +1315,6 @@ class VanillaDestination extends AbstractDestination
         }
 
         foreach ($articles as $article) {
-            $processed[] = $article["articleID"];
             if (in_array($article["foreignID"], $foreignArticleIDs)) {
                 $matched[] = $article["foreignID"];
             } else {
@@ -1348,15 +1338,11 @@ class VanillaDestination extends AbstractDestination
             }
         }
 
-        $this->logger->end(
-            "Synced {processed} articles (matched: {matched}, deleted: {deleted}, failed: {failed})",
-            [
-                "processed" => count($processed),
-                "matched" => count($matched),
-                "deleted" => count($deleted),
-                "failed" => count($failed),
-            ]
-        );
-        return $processed;
+        $processedCount = count($articles);
+        $matchedCount = count($matched);
+        $deletedCount = count($deleted);
+        $failedCount = count($failed);
+        $this->logger->info("Synced $processedCount articles (matched: $matchedCount, deleted: $deletedCount, failed: $failedCount)");
+        return $matched;
     }
 }

--- a/src/Destinations/VanillaMockDestination.php
+++ b/src/Destinations/VanillaMockDestination.php
@@ -57,12 +57,38 @@ class VanillaMockDestination extends AbstractDestination
         return [];
     }
 
-    public function syncArticles(
-        array $zendeskArticles,
-        int $limit,
-        int $page,
-        array $knowledgeBaseIDs = []
+    /**
+     * @inheritDoc
+     */
+    public function syncKnowledgeBase(
+        array $foreignKnowledgeBaseIDs,
+        array $query = []
     ): array {
+        $page = $query["page"];
+        $result = $this->returnMockRecords($page);
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function syncKnowledgeCategories(
+        array $foreignKnowledgeCategoryIDs,
+        array $query = []
+    ): array {
+        $page = $query["page"];
+        $result = $this->returnMockRecords($page);
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function syncArticles(
+        array $foreignArticleIDs,
+        array $query = []
+    ): array {
+        $page = $query["page"];
         $result = $this->returnMockRecords($page);
         return $result;
     }
@@ -74,15 +100,10 @@ class VanillaMockDestination extends AbstractDestination
      */
     protected function returnMockRecords(int $mockValue): array
     {
-        switch ($mockValue) {
-            case self::VALID_PAGE:
-                return ["zd1", "zd2", "zd3"];
-                break;
-            case self::EMPTY_PAGE:
-                return [];
-            case self::INVALID_PAGE:
-            default:
-                throw new Exception("An error has occurred");
-        }
+        return match ($mockValue) {
+            self::VALID_PAGE => ["zd1", "zd2", "zd3"],
+            self::EMPTY_PAGE => [],
+            default => throw new Exception("An error has occurred"),
+        };
     }
 }

--- a/src/Destinations/VanillaMockDestination.php
+++ b/src/Destinations/VanillaMockDestination.php
@@ -63,7 +63,7 @@ class VanillaMockDestination extends AbstractDestination
     public function syncKnowledgeBase(
         array $foreignKnowledgeBaseIDs,
         array $query = []
-    ) {
+    ): array {
         $page = $query["page"];
         $result = $this->returnMockRecords($page);
         return $result;
@@ -75,7 +75,7 @@ class VanillaMockDestination extends AbstractDestination
     public function syncKnowledgeCategories(
         array $foreignKnowledgeCategoryIDs,
         array $query = []
-    ) {
+    ): array {
         $page = $query["page"];
         $result = $this->returnMockRecords($page);
         return $result;
@@ -87,7 +87,7 @@ class VanillaMockDestination extends AbstractDestination
     public function syncArticles(
         array $foreignArticleIDs,
         array $query = []
-    ) {
+    ): array {
         $page = $query["page"];
         $result = $this->returnMockRecords($page);
         return $result;

--- a/src/Destinations/VanillaMockDestination.php
+++ b/src/Destinations/VanillaMockDestination.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @author Olivier Lamy-Canuel <olamy-canuel@higherlogic.com>
+ * @copyright 2009-2023 Higher Logic Inc.
+ * @license Proprietary
+ */
+
+namespace Vanilla\KnowledgePorter\Destinations;
+
+use Exception;
+
+class VanillaMockDestination extends AbstractDestination
+{
+    const VALID_PAGE = 1;
+    const EMPTY_PAGE = 2;
+    const INVALID_PAGE = 3;
+    public function importKnowledgeBases(iterable $rows): iterable
+    {
+        $mock = $this->config["pageFrom"];
+        $result = $this->returnMockRecords($mock);
+        return $result;
+    }
+
+    public function importUsers(iterable $rows): iterable
+    {
+        $mock = $this->config["pageFrom"];
+        $result = $this->returnMockRecords($mock);
+        return $result;
+    }
+
+    public function importKnowledgeCategories(iterable $rows): iterable
+    {
+        $mock = $this->config["pageFrom"];
+        $result = $this->returnMockRecords($mock);
+        return $result;
+    }
+
+    public function importKnowledgeArticles(iterable $rows): iterable
+    {
+        $mock = $this->config["pageFrom"];
+        $result = $this->returnMockRecords($mock);
+        return $result;
+    }
+
+    public function getKnowledgeBaseBySmartID(string $foreignID): array
+    {
+        // TODO: Implement getKnowledgeBaseBySmartID() method.
+        return [];
+    }
+
+    public function deleteArchivedArticles(
+        array $knowledgeBases,
+        array $articles,
+        string $prefix
+    ) {
+        // TODO: Implement deleteArchivedArticles() method.
+        return [];
+    }
+
+    public function syncArticles(
+        array $zendeskArticles,
+        int $limit,
+        int $page,
+        array $knowledgeBaseIDs = []
+    ): array {
+        $result = $this->returnMockRecords($page);
+        return $result;
+    }
+
+    /**
+     * @param int $mockValue
+     * @return array|string[]
+     * @throws Exception
+     */
+    protected function returnMockRecords(int $mockValue): array
+    {
+        switch ($mockValue) {
+            case self::VALID_PAGE:
+                return ["zd1", "zd2", "zd3"];
+                break;
+            case self::EMPTY_PAGE:
+                return [];
+            case self::INVALID_PAGE:
+            default:
+                throw new Exception("An error has occurred");
+        }
+    }
+}

--- a/src/Destinations/VanillaMockDestination.php
+++ b/src/Destinations/VanillaMockDestination.php
@@ -101,8 +101,8 @@ class VanillaMockDestination extends AbstractDestination
     protected function returnMockRecords(int $mockValue): array
     {
         return match ($mockValue) {
-            self::VALID_PAGE => ["zd1", "zd2", "zd3"],
-            self::EMPTY_PAGE => self::NO_DATA,
+            self::VALID_PAGE => ["fetched" => 3, "vanillaIDs" => ["zd1", "zd2", "zd3"]],
+            self::EMPTY_PAGE => ["fetched" => 0, "vanillaIDs" => []],
             default => throw new Exception("An error has occurred"),
         };
     }

--- a/src/Destinations/VanillaMockDestination.php
+++ b/src/Destinations/VanillaMockDestination.php
@@ -63,7 +63,7 @@ class VanillaMockDestination extends AbstractDestination
     public function syncKnowledgeBase(
         array $foreignKnowledgeBaseIDs,
         array $query = []
-    ): array {
+    ) {
         $page = $query["page"];
         $result = $this->returnMockRecords($page);
         return $result;
@@ -75,7 +75,7 @@ class VanillaMockDestination extends AbstractDestination
     public function syncKnowledgeCategories(
         array $foreignKnowledgeCategoryIDs,
         array $query = []
-    ): array {
+    ) {
         $page = $query["page"];
         $result = $this->returnMockRecords($page);
         return $result;
@@ -87,7 +87,7 @@ class VanillaMockDestination extends AbstractDestination
     public function syncArticles(
         array $foreignArticleIDs,
         array $query = []
-    ): array {
+    ) {
         $page = $query["page"];
         $result = $this->returnMockRecords($page);
         return $result;
@@ -102,7 +102,7 @@ class VanillaMockDestination extends AbstractDestination
     {
         return match ($mockValue) {
             self::VALID_PAGE => ["zd1", "zd2", "zd3"],
-            self::EMPTY_PAGE => [],
+            self::EMPTY_PAGE => self::NO_DATA,
             default => throw new Exception("An error has occurred"),
         };
     }

--- a/src/HttpClients/VanillaClient.php
+++ b/src/HttpClients/VanillaClient.php
@@ -16,9 +16,9 @@ use Vanilla\KnowledgePorter\Utils\ApiPaginationIterator;
 /**
  * The Vanilla API.
  */
-class VanillaClient extends HttpClient {
-
-    const DELETED_STATUS = 'deleted';
+class VanillaClient extends HttpClient
+{
+    const DELETED_STATUS = "deleted";
     /**
      * @var string
      */
@@ -33,10 +33,13 @@ class VanillaClient extends HttpClient {
      * @param string $baseUrl
      * @param HttpHandlerInterface|null $handler
      */
-    public function __construct(string $baseUrl = '', HttpHandlerInterface $handler = null) {
+    public function __construct(
+        string $baseUrl = "",
+        HttpHandlerInterface $handler = null
+    ) {
         parent::__construct($baseUrl, $handler);
         $this->setThrowExceptions(true);
-        $this->setDefaultHeader('Content-Type', 'application/json');
+        $this->setDefaultHeader("Content-Type", "application/json");
     }
 
     /**
@@ -44,9 +47,10 @@ class VanillaClient extends HttpClient {
      *
      * @param string $token
      */
-    public function setToken(string $token) {
+    public function setToken(string $token)
+    {
         $this->token = $token;
-        $this->setDefaultHeader('Authorization', "Bearer $token");
+        $this->setDefaultHeader("Authorization", "Bearer $token");
     }
 
     /**
@@ -56,8 +60,12 @@ class VanillaClient extends HttpClient {
      * @param array $query
      * @return array
      */
-    public function getKnowledgeBases(string $locale, array $query = []): array {
-        $result = $this->get("/api/v2/knowledge-bases?locale={$locale}");
+    public function getKnowledgeBases(string $locale, array $query = []): array
+    {
+        $result = $this->get(
+            "/api/v2/knowledge-bases?locale={$locale}",
+            $query
+        );
         $body = $result->getBody();
         return $body;
     }
@@ -69,8 +77,28 @@ class VanillaClient extends HttpClient {
      * @param array $query
      * @return array
      */
-    public function getKnowledgeCategories(string $locale, array $query = []): array {
-        $result = $this->get("/api/v2/knowledge-categories?locale={$locale}");
+    public function getKnowledgeCategories(
+        string $locale,
+        array $query = []
+    ): array {
+        $result = $this->get(
+            "/api/v2/knowledge-categories?locale={$locale}",
+            $query
+        );
+        $body = $result->getBody();
+        return $body;
+    }
+
+    /**
+     * Execute GET /api/v2/articles request against vanilla api.
+     *
+     * @param string $locale
+     * @param array $query
+     * @return array
+     */
+    public function getArticles(string $locale, array $query = []): array
+    {
+        $result = $this->get("/api/v2/articles?locale={$locale}", $query);
         $body = $result->getBody();
         return $body;
     }
@@ -82,8 +110,14 @@ class VanillaClient extends HttpClient {
      * @param array $query
      * @return array
      */
-    public function getKnowledgeBaseBySmartID(string $paramSmartID, array $query = []): array {
-        $result = $this->get("/api/v2/knowledge-bases/".rawurlencode('$foreignID:'.$paramSmartID));
+    public function getKnowledgeBaseBySmartID(
+        string $paramSmartID,
+        array $query = []
+    ): array {
+        $result = $this->get(
+            "/api/v2/knowledge-bases/" .
+                rawurlencode('$foreignID:' . $paramSmartID)
+        );
         $body = $result->getBody();
         return $body;
     }
@@ -95,12 +129,18 @@ class VanillaClient extends HttpClient {
      * @param array $query
      * @return array
      */
-    public function getKnowledgeCategoryBySmartID(string $paramSmartID, array $query = []): array {
+    public function getKnowledgeCategoryBySmartID(
+        string $paramSmartID,
+        array $query = []
+    ): array {
         $existing = $this->categoryCacheByID[$paramSmartID] ?? null;
         if ($existing) {
             return $existing;
         }
-        $result = $this->get("/api/v2/knowledge-categories/".rawurlencode('$foreignID:'.$paramSmartID));
+        $result = $this->get(
+            "/api/v2/knowledge-categories/" .
+                rawurlencode('$foreignID:' . $paramSmartID)
+        );
         $body = $result->getBody();
         $this->categoryCacheByID[$paramSmartID] = $body;
         return $body;
@@ -112,8 +152,9 @@ class VanillaClient extends HttpClient {
      * @param array $query
      * @return array
      */
-    public function getKnowledgeBaseTranslation(array $query = []): array {
-        $query['validateLocale'] = $query['validateLocale'] ?? false;
+    public function getKnowledgeBaseTranslation(array $query = []): array
+    {
+        $query["validateLocale"] = $query["validateLocale"] ?? false;
         $result = $this->get("/api/v2/translations/kb", $query);
         $body = $result->getBody();
         if (count($body) === 1) {
@@ -129,8 +170,15 @@ class VanillaClient extends HttpClient {
      * @param array $query
      * @return array
      */
-    public function getKnowledgeArticleBySmartID(string $paramSmartID, array $query = []): array {
-        $result = $this->get("/api/v2/articles/".rawurlencode('$foreignID:'.$paramSmartID).'/edit');
+    public function getKnowledgeArticleBySmartID(
+        string $paramSmartID,
+        array $query = []
+    ): array {
+        $result = $this->get(
+            "/api/v2/articles/" .
+                rawurlencode('$foreignID:' . $paramSmartID) .
+                "/edit"
+        );
         $body = $result->getBody();
         return $body;
     }
@@ -141,8 +189,11 @@ class VanillaClient extends HttpClient {
      * @param array $ids
      * @return array
      */
-    public function getKnowledgeCategoriesByKnowledgeBaseID(array $ids): array {
-        $url = '/api/v2/knowledge-categories?'.http_build_query(["knowledgeBaseIDs" => $ids]);
+    public function getKnowledgeCategoriesByKnowledgeBaseID(array $ids): array
+    {
+        $url =
+            "/api/v2/knowledge-categories?" .
+            http_build_query(["knowledgeBaseIDs" => $ids]);
 
         /** @var ApiPaginationIterator $iterator */
         $iterator = new ApiPaginationIterator($this, $url);
@@ -161,8 +212,11 @@ class VanillaClient extends HttpClient {
      * @param int $id
      * @return array
      */
-    public function getKnowledgeArticlesByKnowledgeCategoryID(int $id): array {
-        $url = '/api/v2/articles?'.http_build_query(["knowledgeCategoryID" => $id]);
+    public function getKnowledgeArticlesByKnowledgeCategoryID(int $id): array
+    {
+        $url =
+            "/api/v2/articles?" .
+            http_build_query(["knowledgeCategoryID" => $id]);
 
         /** @var ApiPaginationIterator $iterator */
         $iterator = new ApiPaginationIterator($this, $url);
@@ -181,17 +235,20 @@ class VanillaClient extends HttpClient {
      * @param int $id
      * @return array
      */
-    public function updateKnowledgeArticleStatus(int $id): array {
-        $result = $this->patch("/api/v2/articles/$id/status", ["status" => self::DELETED_STATUS]);
+    public function updateKnowledgeArticleStatus(int $id): array
+    {
+        $result = $this->patch("/api/v2/articles/$id/status", [
+            "status" => self::DELETED_STATUS,
+        ]);
         $body = $result->getBody();
         return $body;
     }
 
-
     /**
      * @return string
      */
-    public function getToken(): string {
+    public function getToken(): string
+    {
         return $this->token;
     }
 
@@ -203,15 +260,27 @@ class VanillaClient extends HttpClient {
      * @throws NotFoundException Throw not found exception when 404 status received.
      * @throws HttpResponseException On error
      */
-    public function handleErrorResponse(HttpResponse $response, $options = []) {
-        if ($response->getStatusCode() === 404 && ($options['throw'] ?? $this->throwExceptions)) {
-            throw new NotFoundException($response, $response['message'] ?? '');
-        } elseif (is_array($response->getBody()) && !empty($response->getBody()['errors'])) {
-            $message = $this->makeValidationMessage($response->getBody()['errors']);
+    public function handleErrorResponse(HttpResponse $response, $options = [])
+    {
+        if (
+            $response->getStatusCode() === 404 &&
+            ($options["throw"] ?? $this->throwExceptions)
+        ) {
+            throw new NotFoundException($response, $response["message"] ?? "");
+        } elseif (
+            is_array($response->getBody()) &&
+            !empty($response->getBody()["errors"])
+        ) {
+            $message = $this->makeValidationMessage(
+                $response->getBody()["errors"]
+            );
             if (!empty($message)) {
                 throw new HttpResponseException($response, $message);
             }
-        } elseif ($response->getStatusCode() >= 500 && ($options['throw'] ?? $this->throwExceptions)) {
+        } elseif (
+            $response->getStatusCode() >= 500 &&
+            ($options["throw"] ?? $this->throwExceptions)
+        ) {
             throw new HttpResponseException($response, $response->getRawBody());
         } else {
             parent::handleErrorResponse($response, $options);
@@ -224,19 +293,20 @@ class VanillaClient extends HttpClient {
      * @param array $errors The list of validation errors.
      * @return string Returns the final error message.
      */
-    private function makeValidationMessage($errors): string {
+    private function makeValidationMessage($errors): string
+    {
         if (!is_array($errors)) {
-            return '';
+            return "";
         }
         $fieldErrors = [];
         foreach ($errors as $error) {
-            $fieldErrors[$error['field']][] = $error['message'];
+            $fieldErrors[$error["field"]][] = $error["message"];
         }
         $result = [];
         foreach ($fieldErrors as $field => $errors) {
-            $result[] = $field.': '.implode(', ', $errors);
+            $result[] = $field . ": " . implode(", ", $errors);
         }
-        $message = implode('; ', $result);
+        $message = implode("; ", $result);
         return $message;
     }
 }

--- a/src/HttpClients/VanillaClient.php
+++ b/src/HttpClients/VanillaClient.php
@@ -16,9 +16,9 @@ use Vanilla\KnowledgePorter\Utils\ApiPaginationIterator;
 /**
  * The Vanilla API.
  */
-class VanillaClient extends HttpClient
-{
-    const DELETED_STATUS = "deleted";
+class VanillaClient extends HttpClient {
+
+    const DELETED_STATUS = 'deleted';
     /**
      * @var string
      */
@@ -33,13 +33,10 @@ class VanillaClient extends HttpClient
      * @param string $baseUrl
      * @param HttpHandlerInterface|null $handler
      */
-    public function __construct(
-        string $baseUrl = "",
-        HttpHandlerInterface $handler = null
-    ) {
+    public function __construct(string $baseUrl = '', HttpHandlerInterface $handler = null) {
         parent::__construct($baseUrl, $handler);
         $this->setThrowExceptions(true);
-        $this->setDefaultHeader("Content-Type", "application/json");
+        $this->setDefaultHeader('Content-Type', 'application/json');
     }
 
     /**
@@ -47,10 +44,9 @@ class VanillaClient extends HttpClient
      *
      * @param string $token
      */
-    public function setToken(string $token)
-    {
+    public function setToken(string $token) {
         $this->token = $token;
-        $this->setDefaultHeader("Authorization", "Bearer $token");
+        $this->setDefaultHeader('Authorization', "Bearer $token");
     }
 
     /**
@@ -99,14 +95,8 @@ class VanillaClient extends HttpClient
      * @param array $query
      * @return array
      */
-    public function getKnowledgeBaseBySmartID(
-        string $paramSmartID,
-        array $query = []
-    ): array {
-        $result = $this->get(
-            "/api/v2/knowledge-bases/" .
-                rawurlencode('$foreignID:' . $paramSmartID)
-        );
+    public function getKnowledgeBaseBySmartID(string $paramSmartID, array $query = []): array {
+        $result = $this->get("/api/v2/knowledge-bases/".rawurlencode('$foreignID:'.$paramSmartID));
         $body = $result->getBody();
         return $body;
     }
@@ -118,18 +108,12 @@ class VanillaClient extends HttpClient
      * @param array $query
      * @return array
      */
-    public function getKnowledgeCategoryBySmartID(
-        string $paramSmartID,
-        array $query = []
-    ): array {
+    public function getKnowledgeCategoryBySmartID(string $paramSmartID, array $query = []): array {
         $existing = $this->categoryCacheByID[$paramSmartID] ?? null;
         if ($existing) {
             return $existing;
         }
-        $result = $this->get(
-            "/api/v2/knowledge-categories/" .
-                rawurlencode('$foreignID:' . $paramSmartID)
-        );
+        $result = $this->get("/api/v2/knowledge-categories/".rawurlencode('$foreignID:'.$paramSmartID));
         $body = $result->getBody();
         $this->categoryCacheByID[$paramSmartID] = $body;
         return $body;
@@ -141,9 +125,8 @@ class VanillaClient extends HttpClient
      * @param array $query
      * @return array
      */
-    public function getKnowledgeBaseTranslation(array $query = []): array
-    {
-        $query["validateLocale"] = $query["validateLocale"] ?? false;
+    public function getKnowledgeBaseTranslation(array $query = []): array {
+        $query['validateLocale'] = $query['validateLocale'] ?? false;
         $result = $this->get("/api/v2/translations/kb", $query);
         $body = $result->getBody();
         if (count($body) === 1) {
@@ -159,15 +142,8 @@ class VanillaClient extends HttpClient
      * @param array $query
      * @return array
      */
-    public function getKnowledgeArticleBySmartID(
-        string $paramSmartID,
-        array $query = []
-    ): array {
-        $result = $this->get(
-            "/api/v2/articles/" .
-                rawurlencode('$foreignID:' . $paramSmartID) .
-                "/edit"
-        );
+    public function getKnowledgeArticleBySmartID(string $paramSmartID, array $query = []): array {
+        $result = $this->get("/api/v2/articles/".rawurlencode('$foreignID:'.$paramSmartID).'/edit');
         $body = $result->getBody();
         return $body;
     }
@@ -178,11 +154,8 @@ class VanillaClient extends HttpClient
      * @param array $ids
      * @return array
      */
-    public function getKnowledgeCategoriesByKnowledgeBaseID(array $ids): array
-    {
-        $url =
-            "/api/v2/knowledge-categories?" .
-            http_build_query(["knowledgeBaseIDs" => $ids]);
+    public function getKnowledgeCategoriesByKnowledgeBaseID(array $ids): array {
+        $url = '/api/v2/knowledge-categories?'.http_build_query(["knowledgeBaseIDs" => $ids]);
 
         /** @var ApiPaginationIterator $iterator */
         $iterator = new ApiPaginationIterator($this, $url);
@@ -201,11 +174,8 @@ class VanillaClient extends HttpClient
      * @param int $id
      * @return array
      */
-    public function getKnowledgeArticlesByKnowledgeCategoryID(int $id): array
-    {
-        $url =
-            "/api/v2/articles?" .
-            http_build_query(["knowledgeCategoryID" => $id]);
+    public function getKnowledgeArticlesByKnowledgeCategoryID(int $id): array {
+        $url = '/api/v2/articles?'.http_build_query(["knowledgeCategoryID" => $id]);
 
         /** @var ApiPaginationIterator $iterator */
         $iterator = new ApiPaginationIterator($this, $url);
@@ -224,20 +194,17 @@ class VanillaClient extends HttpClient
      * @param int $id
      * @return array
      */
-    public function updateKnowledgeArticleStatus(int $id): array
-    {
-        $result = $this->patch("/api/v2/articles/$id/status", [
-            "status" => self::DELETED_STATUS,
-        ]);
+    public function updateKnowledgeArticleStatus(int $id): array {
+        $result = $this->patch("/api/v2/articles/$id/status", ["status" => self::DELETED_STATUS]);
         $body = $result->getBody();
         return $body;
     }
 
+
     /**
      * @return string
      */
-    public function getToken(): string
-    {
+    public function getToken(): string {
         return $this->token;
     }
 
@@ -249,27 +216,15 @@ class VanillaClient extends HttpClient
      * @throws NotFoundException Throw not found exception when 404 status received.
      * @throws HttpResponseException On error
      */
-    public function handleErrorResponse(HttpResponse $response, $options = [])
-    {
-        if (
-            $response->getStatusCode() === 404 &&
-            ($options["throw"] ?? $this->throwExceptions)
-        ) {
-            throw new NotFoundException($response, $response["message"] ?? "");
-        } elseif (
-            is_array($response->getBody()) &&
-            !empty($response->getBody()["errors"])
-        ) {
-            $message = $this->makeValidationMessage(
-                $response->getBody()["errors"]
-            );
+    public function handleErrorResponse(HttpResponse $response, $options = []) {
+        if ($response->getStatusCode() === 404 && ($options['throw'] ?? $this->throwExceptions)) {
+            throw new NotFoundException($response, $response['message'] ?? '');
+        } elseif (is_array($response->getBody()) && !empty($response->getBody()['errors'])) {
+            $message = $this->makeValidationMessage($response->getBody()['errors']);
             if (!empty($message)) {
                 throw new HttpResponseException($response, $message);
             }
-        } elseif (
-            $response->getStatusCode() >= 500 &&
-            ($options["throw"] ?? $this->throwExceptions)
-        ) {
+        } elseif ($response->getStatusCode() >= 500 && ($options['throw'] ?? $this->throwExceptions)) {
             throw new HttpResponseException($response, $response->getRawBody());
         } else {
             parent::handleErrorResponse($response, $options);
@@ -282,20 +237,19 @@ class VanillaClient extends HttpClient
      * @param array $errors The list of validation errors.
      * @return string Returns the final error message.
      */
-    private function makeValidationMessage($errors): string
-    {
+    private function makeValidationMessage($errors): string {
         if (!is_array($errors)) {
-            return "";
+            return '';
         }
         $fieldErrors = [];
         foreach ($errors as $error) {
-            $fieldErrors[$error["field"]][] = $error["message"];
+            $fieldErrors[$error['field']][] = $error['message'];
         }
         $result = [];
         foreach ($fieldErrors as $field => $errors) {
-            $result[] = $field . ": " . implode(", ", $errors);
+            $result[] = $field.': '.implode(', ', $errors);
         }
-        $message = implode("; ", $result);
+        $message = implode('; ', $result);
         return $message;
     }
 }

--- a/src/HttpClients/VanillaClient.php
+++ b/src/HttpClients/VanillaClient.php
@@ -56,16 +56,12 @@ class VanillaClient extends HttpClient
     /**
      * Execute GET /api/v2/knowledge-bases request against vanilla api.
      *
-     * @param string $locale
      * @param array $query
      * @return array
      */
-    public function getKnowledgeBases(string $locale, array $query = []): array
+    public function getKnowledgeBases(array $query = []): array
     {
-        $result = $this->get(
-            "/api/v2/knowledge-bases?locale={$locale}",
-            $query
-        );
+        $result = $this->get("/api/v2/knowledge-bases", $query);
         $body = $result->getBody();
         return $body;
     }
@@ -73,18 +69,12 @@ class VanillaClient extends HttpClient
     /**
      * Execute GET /api/v2/knowledge-categories request against vanilla api.
      *
-     * @param string $locale
      * @param array $query
      * @return array
      */
-    public function getKnowledgeCategories(
-        string $locale,
-        array $query = []
-    ): array {
-        $result = $this->get(
-            "/api/v2/knowledge-categories?locale={$locale}",
-            $query
-        );
+    public function getKnowledgeCategories(array $query = []): array
+    {
+        $result = $this->get("/api/v2/knowledge-categories", $query);
         $body = $result->getBody();
         return $body;
     }
@@ -92,13 +82,12 @@ class VanillaClient extends HttpClient
     /**
      * Execute GET /api/v2/articles request against vanilla api.
      *
-     * @param string $locale
      * @param array $query
      * @return array
      */
-    public function getArticles(string $locale, array $query = []): array
+    public function getArticles(array $query = []): array
     {
-        $result = $this->get("/api/v2/articles?locale={$locale}", $query);
+        $result = $this->get("/api/v2/articles", $query);
         $body = $result->getBody();
         return $body;
     }

--- a/src/Sources/VanillaSource.php
+++ b/src/Sources/VanillaSource.php
@@ -13,7 +13,8 @@ use Vanilla\KnowledgePorter\HttpClients\VanillaClient;
  * Class VanillaSource
  * @package Vanilla\KnowledgePorter\Sources
  */
-class VanillaSource extends AbstractSource {
+class VanillaSource extends AbstractSource
+{
     /**
      * @var VanillaClient
      */
@@ -23,7 +24,8 @@ class VanillaSource extends AbstractSource {
      * VanillaSource constructor.
      * @param VanillaClient $vanilla
      */
-    public function __construct(VanillaClient $vanilla) {
+    public function __construct(VanillaClient $vanilla)
+    {
         $this->vanillaApi = $vanilla;
     }
 
@@ -32,14 +34,16 @@ class VanillaSource extends AbstractSource {
      *
      * @param string $basePath
      */
-    public function setBasePath(string $basePath) {
+    public function setBasePath(string $basePath)
+    {
         $this->basePath = $basePath;
     }
 
     /**
      * Execute import content actions
      */
-    public function import(): void {
+    public function import(): void
+    {
         $this->processKnowledgeBases();
         $this->processKnowledgeCategories();
         $this->processArticles();
@@ -48,19 +52,31 @@ class VanillaSource extends AbstractSource {
     /**
      * Process: GET knowledge bases, POST/PATCH vanilla knowledge bases
      */
-    private function processKnowledgeBases() {
+    private function processKnowledgeBases()
+    {
         $dest = $this->getDestination();
-        $knowledgeBases = $this->vanillaApi->getKnowledgeBases('en');
+        $knowledgeBases = $this->vanillaApi->getKnowledgeBases([
+            "locale" => "en",
+        ]);
         $kbs = $this->transform($knowledgeBases, [
-            'foreignID' => ["column" =>'knowledgeBaseID', "filter" => [$this, "addPrefix"]],
-            'name' => 'name',
-            'description' => 'description',
-            'icon' => 'icon',
-            'urlCode' => ["column" => 'urlCode', "filter" => [$this, "addPrefix"]],
-            'sourceLocale' => 'sourceLocale',
-            'viewType' => 'viewType',
-            'sortArticles' => 'sortArticles',
-            'skip' => ["column" =>'foreignID', "filter" => [$this, "isOrigin"]],
+            "foreignID" => [
+                "column" => "knowledgeBaseID",
+                "filter" => [$this, "addPrefix"],
+            ],
+            "name" => "name",
+            "description" => "description",
+            "icon" => "icon",
+            "urlCode" => [
+                "column" => "urlCode",
+                "filter" => [$this, "addPrefix"],
+            ],
+            "sourceLocale" => "sourceLocale",
+            "viewType" => "viewType",
+            "sortArticles" => "sortArticles",
+            "skip" => [
+                "column" => "foreignID",
+                "filter" => [$this, "isOrigin"],
+            ],
         ]);
 
         $dest->importKnowledgeBases($kbs);
@@ -70,24 +86,46 @@ class VanillaSource extends AbstractSource {
      * Vanilla does not have any need for rehosting headers.
      * @return array
      */
-    public function getFileRehostingHeaders(): array {
+    public function getFileRehostingHeaders(): array
+    {
         return [];
     }
 
     /**
      * Process: GET vanilla kb categories, POST/PATCH vanilla knowledge categories
      */
-    private function processKnowledgeCategories() {
-        $categories = $this->vanillaApi->getKnowledgeCategories('en', ['knowledgeBaseID']);
+    private function processKnowledgeCategories()
+    {
+        $query = [
+            "locale" => "en",
+        ];
+        $categories = $this->vanillaApi->getKnowledgeCategories($query);
         $knowledgeCategories = $this->transform($categories, [
-            'foreignID' => ["column" =>'knowledgeCategoryID', "filter" => [$this, "addPrefix"]],
-            'knowledgeBaseID' => ["column" =>'knowledgeBaseID', "filter" => [$this, "knowledgeBaseSmartId"]],
-            'parentID' => ["column" =>'parentID', "filter" => [$this, "calculateParentID"]],
-            'name' => 'name',
-            'rootCategory' => ["column" =>'parentID', "filter" => [$this, "isRoot"]],
-            'sourceParentID' => ["column" =>'parentID', "filter" => [$this, "isRoot"]],
-            'skip' => ["column" =>'knowledgeBaseID', "filter" => [$this, "isOriginKb"]],
-
+            "foreignID" => [
+                "column" => "knowledgeCategoryID",
+                "filter" => [$this, "addPrefix"],
+            ],
+            "knowledgeBaseID" => [
+                "column" => "knowledgeBaseID",
+                "filter" => [$this, "knowledgeBaseSmartId"],
+            ],
+            "parentID" => [
+                "column" => "parentID",
+                "filter" => [$this, "calculateParentID"],
+            ],
+            "name" => "name",
+            "rootCategory" => [
+                "column" => "parentID",
+                "filter" => [$this, "isRoot"],
+            ],
+            "sourceParentID" => [
+                "column" => "parentID",
+                "filter" => [$this, "isRoot"],
+            ],
+            "skip" => [
+                "column" => "knowledgeBaseID",
+                "filter" => [$this, "isOriginKb"],
+            ],
         ]);
         $dest = $this->getDestination();
         $dest->importKnowledgeCategories($knowledgeCategories);
@@ -96,7 +134,8 @@ class VanillaSource extends AbstractSource {
     /**
      * Process: GET vanilla kb articles, POST/PATCH vanilla knowledge base articles
      */
-    private function processArticles() {
+    private function processArticles()
+    {
         return [];
     }
 
@@ -106,8 +145,9 @@ class VanillaSource extends AbstractSource {
      * @param mixed $str
      * @return string
      */
-    protected function addPrefix($str): string {
-        $newStr = $this->config["foreignIDPrefix"].$str;
+    protected function addPrefix($str): string
+    {
+        $newStr = $this->config["foreignIDPrefix"] . $str;
         return $newStr;
     }
 
@@ -117,8 +157,9 @@ class VanillaSource extends AbstractSource {
      * @param mixed $str
      * @return string
      */
-    protected function knowledgeCategorySmartId($str): string {
-        $newStr = '$foreignID:'.$this->config["foreignIDPrefix"].$str;
+    protected function knowledgeCategorySmartId($str): string
+    {
+        $newStr = '$foreignID:' . $this->config["foreignIDPrefix"] . $str;
         return $newStr;
     }
 
@@ -128,7 +169,8 @@ class VanillaSource extends AbstractSource {
      * @param mixed $str
      * @return string
      */
-    protected function calculateParentID($str): string {
+    protected function calculateParentID($str): string
+    {
         if ($str != "-1") {
             $newStr = '$foreignID:' . $this->config["foreignIDPrefix"] . $str;
         } else {
@@ -143,11 +185,12 @@ class VanillaSource extends AbstractSource {
      * @param mixed $str
      * @return string
      */
-    protected function isRoot($str): string {
+    protected function isRoot($str): string
+    {
         if ($str == "-1") {
-            $newStr = 'true';
+            $newStr = "true";
         } else {
-            $newStr = 'false';
+            $newStr = "false";
         }
 
         return $newStr;
@@ -160,8 +203,9 @@ class VanillaSource extends AbstractSource {
      * @param mixed $str Check foreignID field
      * @return string
      */
-    protected function isOrigin($str): string {
-        $newStr = !empty($str) ? 'true' : 'false';
+    protected function isOrigin($str): string
+    {
+        $newStr = !empty($str) ? "true" : "false";
         return $newStr;
     }
 
@@ -172,12 +216,13 @@ class VanillaSource extends AbstractSource {
      * @param mixed $str
      * @return string
      */
-    protected function isOriginKb($str): string {
-        $max = $this->config['maxKbID'] ?? false;
+    protected function isOriginKb($str): string
+    {
+        $max = $this->config["maxKbID"] ?? false;
         if ($max) {
-            $newStr = ($str > $max) ? "true" : 'false';
+            $newStr = $str > $max ? "true" : "false";
         } else {
-            $newStr = 'false';
+            $newStr = "false";
         }
 
         return $newStr;
@@ -189,8 +234,9 @@ class VanillaSource extends AbstractSource {
      * @param mixed $str
      * @return string
      */
-    protected function knowledgeBaseSmartId($str): string {
-        $newStr = '$foreignID:'.$this->config["foreignIDPrefix"].$str;
+    protected function knowledgeBaseSmartId($str): string
+    {
+        $newStr = '$foreignID:' . $this->config["foreignIDPrefix"] . $str;
         return $newStr;
     }
 
@@ -199,9 +245,10 @@ class VanillaSource extends AbstractSource {
      *
      * @param array $config
      */
-    public function setConfig(array $config): void {
+    public function setConfig(array $config): void
+    {
         $this->config = $config;
-        $this->vanillaApi->setToken($this->config['token']);
-        $this->vanillaApi->setBaseUrl($this->config['baseUrl']);
+        $this->vanillaApi->setToken($this->config["token"]);
+        $this->vanillaApi->setBaseUrl($this->config["baseUrl"]);
     }
 }

--- a/src/Sources/VanillaSource.php
+++ b/src/Sources/VanillaSource.php
@@ -13,8 +13,7 @@ use Vanilla\KnowledgePorter\HttpClients\VanillaClient;
  * Class VanillaSource
  * @package Vanilla\KnowledgePorter\Sources
  */
-class VanillaSource extends AbstractSource
-{
+class VanillaSource extends AbstractSource {
     /**
      * @var VanillaClient
      */
@@ -24,8 +23,7 @@ class VanillaSource extends AbstractSource
      * VanillaSource constructor.
      * @param VanillaClient $vanilla
      */
-    public function __construct(VanillaClient $vanilla)
-    {
+    public function __construct(VanillaClient $vanilla) {
         $this->vanillaApi = $vanilla;
     }
 
@@ -34,16 +32,14 @@ class VanillaSource extends AbstractSource
      *
      * @param string $basePath
      */
-    public function setBasePath(string $basePath)
-    {
+    public function setBasePath(string $basePath) {
         $this->basePath = $basePath;
     }
 
     /**
      * Execute import content actions
      */
-    public function import(): void
-    {
+    public function import(): void {
         $this->processKnowledgeBases();
         $this->processKnowledgeCategories();
         $this->processArticles();
@@ -52,31 +48,21 @@ class VanillaSource extends AbstractSource
     /**
      * Process: GET knowledge bases, POST/PATCH vanilla knowledge bases
      */
-    private function processKnowledgeBases()
-    {
+    private function processKnowledgeBases() {
         $dest = $this->getDestination();
         $knowledgeBases = $this->vanillaApi->getKnowledgeBases([
             "locale" => "en",
         ]);
         $kbs = $this->transform($knowledgeBases, [
-            "foreignID" => [
-                "column" => "knowledgeBaseID",
-                "filter" => [$this, "addPrefix"],
-            ],
-            "name" => "name",
-            "description" => "description",
-            "icon" => "icon",
-            "urlCode" => [
-                "column" => "urlCode",
-                "filter" => [$this, "addPrefix"],
-            ],
-            "sourceLocale" => "sourceLocale",
-            "viewType" => "viewType",
-            "sortArticles" => "sortArticles",
-            "skip" => [
-                "column" => "foreignID",
-                "filter" => [$this, "isOrigin"],
-            ],
+            'foreignID' => ["column" =>'knowledgeBaseID', "filter" => [$this, "addPrefix"]],
+            'name' => 'name',
+            'description' => 'description',
+            'icon' => 'icon',
+            'urlCode' => ["column" => 'urlCode', "filter" => [$this, "addPrefix"]],
+            'sourceLocale' => 'sourceLocale',
+            'viewType' => 'viewType',
+            'sortArticles' => 'sortArticles',
+            'skip' => ["column" =>'foreignID', "filter" => [$this, "isOrigin"]],
         ]);
 
         $dest->importKnowledgeBases($kbs);
@@ -86,8 +72,7 @@ class VanillaSource extends AbstractSource
      * Vanilla does not have any need for rehosting headers.
      * @return array
      */
-    public function getFileRehostingHeaders(): array
-    {
+    public function getFileRehostingHeaders(): array {
         return [];
     }
 
@@ -101,31 +86,14 @@ class VanillaSource extends AbstractSource
         ];
         $categories = $this->vanillaApi->getKnowledgeCategories($query);
         $knowledgeCategories = $this->transform($categories, [
-            "foreignID" => [
-                "column" => "knowledgeCategoryID",
-                "filter" => [$this, "addPrefix"],
-            ],
-            "knowledgeBaseID" => [
-                "column" => "knowledgeBaseID",
-                "filter" => [$this, "knowledgeBaseSmartId"],
-            ],
-            "parentID" => [
-                "column" => "parentID",
-                "filter" => [$this, "calculateParentID"],
-            ],
-            "name" => "name",
-            "rootCategory" => [
-                "column" => "parentID",
-                "filter" => [$this, "isRoot"],
-            ],
-            "sourceParentID" => [
-                "column" => "parentID",
-                "filter" => [$this, "isRoot"],
-            ],
-            "skip" => [
-                "column" => "knowledgeBaseID",
-                "filter" => [$this, "isOriginKb"],
-            ],
+            'foreignID' => ["column" =>'knowledgeCategoryID', "filter" => [$this, "addPrefix"]],
+            'knowledgeBaseID' => ["column" =>'knowledgeBaseID', "filter" => [$this, "knowledgeBaseSmartId"]],
+            'parentID' => ["column" =>'parentID', "filter" => [$this, "calculateParentID"]],
+            'name' => 'name',
+            'rootCategory' => ["column" =>'parentID', "filter" => [$this, "isRoot"]],
+            'sourceParentID' => ["column" =>'parentID', "filter" => [$this, "isRoot"]],
+            'skip' => ["column" =>'knowledgeBaseID', "filter" => [$this, "isOriginKb"]],
+
         ]);
         $dest = $this->getDestination();
         $dest->importKnowledgeCategories($knowledgeCategories);
@@ -134,8 +102,7 @@ class VanillaSource extends AbstractSource
     /**
      * Process: GET vanilla kb articles, POST/PATCH vanilla knowledge base articles
      */
-    private function processArticles()
-    {
+    private function processArticles() {
         return [];
     }
 
@@ -145,9 +112,8 @@ class VanillaSource extends AbstractSource
      * @param mixed $str
      * @return string
      */
-    protected function addPrefix($str): string
-    {
-        $newStr = $this->config["foreignIDPrefix"] . $str;
+    protected function addPrefix($str): string {
+        $newStr = $this->config["foreignIDPrefix"].$str;
         return $newStr;
     }
 
@@ -157,9 +123,8 @@ class VanillaSource extends AbstractSource
      * @param mixed $str
      * @return string
      */
-    protected function knowledgeCategorySmartId($str): string
-    {
-        $newStr = '$foreignID:' . $this->config["foreignIDPrefix"] . $str;
+    protected function knowledgeCategorySmartId($str): string {
+        $newStr = '$foreignID:'.$this->config["foreignIDPrefix"].$str;
         return $newStr;
     }
 
@@ -169,8 +134,7 @@ class VanillaSource extends AbstractSource
      * @param mixed $str
      * @return string
      */
-    protected function calculateParentID($str): string
-    {
+    protected function calculateParentID($str): string {
         if ($str != "-1") {
             $newStr = '$foreignID:' . $this->config["foreignIDPrefix"] . $str;
         } else {
@@ -185,12 +149,11 @@ class VanillaSource extends AbstractSource
      * @param mixed $str
      * @return string
      */
-    protected function isRoot($str): string
-    {
+    protected function isRoot($str): string {
         if ($str == "-1") {
-            $newStr = "true";
+            $newStr = 'true';
         } else {
-            $newStr = "false";
+            $newStr = 'false';
         }
 
         return $newStr;
@@ -203,9 +166,8 @@ class VanillaSource extends AbstractSource
      * @param mixed $str Check foreignID field
      * @return string
      */
-    protected function isOrigin($str): string
-    {
-        $newStr = !empty($str) ? "true" : "false";
+    protected function isOrigin($str): string {
+        $newStr = !empty($str) ? 'true' : 'false';
         return $newStr;
     }
 
@@ -216,13 +178,12 @@ class VanillaSource extends AbstractSource
      * @param mixed $str
      * @return string
      */
-    protected function isOriginKb($str): string
-    {
-        $max = $this->config["maxKbID"] ?? false;
+    protected function isOriginKb($str): string {
+        $max = $this->config['maxKbID'] ?? false;
         if ($max) {
-            $newStr = $str > $max ? "true" : "false";
+            $newStr = ($str > $max) ? "true" : 'false';
         } else {
-            $newStr = "false";
+            $newStr = 'false';
         }
 
         return $newStr;
@@ -234,9 +195,8 @@ class VanillaSource extends AbstractSource
      * @param mixed $str
      * @return string
      */
-    protected function knowledgeBaseSmartId($str): string
-    {
-        $newStr = '$foreignID:' . $this->config["foreignIDPrefix"] . $str;
+    protected function knowledgeBaseSmartId($str): string {
+        $newStr = '$foreignID:'.$this->config["foreignIDPrefix"].$str;
         return $newStr;
     }
 
@@ -245,10 +205,9 @@ class VanillaSource extends AbstractSource
      *
      * @param array $config
      */
-    public function setConfig(array $config): void
-    {
+    public function setConfig(array $config): void {
         $this->config = $config;
-        $this->vanillaApi->setToken($this->config["token"]);
-        $this->vanillaApi->setBaseUrl($this->config["baseUrl"]);
+        $this->vanillaApi->setToken($this->config['token']);
+        $this->vanillaApi->setBaseUrl($this->config['baseUrl']);
     }
 }

--- a/src/Sources/ZendeskMockSource.php
+++ b/src/Sources/ZendeskMockSource.php
@@ -11,9 +11,9 @@ use Exception;
 
 class ZendeskMockSource extends ZendeskSource
 {
-    const VALID_PAGE = 1;
-    const INVALID_PAGE = -1;
-    const EMPTY_PAGE = 0;
+    const VALID_RESPONSE = 1;
+    const INVALID_RESPONSE = -1;
+    const EMPTY_RESPONSE = 0;
 
     /**
      * Mock a call made to ZendeskSource::processKnowledgeBases().
@@ -59,12 +59,12 @@ class ZendeskMockSource extends ZendeskSource
     protected function returnMockRecords(int $mockValue): array
     {
         switch ($mockValue) {
-            case self::VALID_PAGE:
+            case self::VALID_RESPONSE:
                 return ["zd1", "zd2", "zd3"];
                 break;
-            case self::EMPTY_PAGE:
+            case self::EMPTY_RESPONSE:
                 return [];
-            case self::INVALID_PAGE:
+            case self::INVALID_RESPONSE:
             default:
                 throw new Exception("An error has occurred");
         }

--- a/src/Sources/ZendeskMockSource.php
+++ b/src/Sources/ZendeskMockSource.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @author Olivier Lamy-Canuel <olamy-canuel@higherlogic.com>
+ * @copyright 2009-2023 Higher Logic Inc.
+ * @license Proprietary
+ */
+
+namespace Vanilla\KnowledgePorter\Sources;
+
+use Exception;
+
+class ZendeskMockSource extends ZendeskSource
+{
+    const VALID_PAGE = 1;
+    const INVALID_PAGE = -1;
+    const EMPTY_PAGE = 0;
+
+    /**
+     * Mock a call made to ZendeskSource::processKnowledgeBases().
+     *
+     * @return array
+     */
+    public function processKnowledgeBases(): array
+    {
+        $mock = $this->config["mock"];
+        $result = $this->returnMockRecords($mock);
+        return $result;
+    }
+
+    /**
+     * Mock a call made to ZendeskSource::processKnowledgeCategories().
+     *
+     * @return array
+     */
+    public function processKnowledgeCategories(): array
+    {
+        $mock = $this->config["mock"];
+        $result = $this->returnMockRecords($mock);
+        return $result;
+    }
+
+    /**
+     * Mock a call made to ZendeskSource::processKnowledgeArticles.
+     *
+     * @return array
+     */
+    public function processKnowledgeArticles(): array
+    {
+        $mock = $this->config["mock"];
+        $result = $this->returnMockRecords($mock);
+        return $result;
+    }
+
+    /**
+     * @param int $mockValue
+     * @return array|string[]
+     * @throws Exception
+     */
+    protected function returnMockRecords(int $mockValue): array
+    {
+        switch ($mockValue) {
+            case self::VALID_PAGE:
+                return ["zd1", "zd2", "zd3"];
+                break;
+            case self::EMPTY_PAGE:
+                return [];
+            case self::INVALID_PAGE:
+            default:
+                throw new Exception("An error has occurred");
+        }
+    }
+}

--- a/src/Sources/ZendeskMockSource.php
+++ b/src/Sources/ZendeskMockSource.php
@@ -9,20 +9,24 @@ namespace Vanilla\KnowledgePorter\Sources;
 
 use Exception;
 
+/**
+ * Mock the return values of the process functions from a ZendeskSource.
+ */
 class ZendeskMockSource extends ZendeskSource
 {
-    const VALID_RESPONSE = 1;
-    const INVALID_RESPONSE = -1;
-    const EMPTY_RESPONSE = 0;
+    const VALID_PAGE = 1;
+    const EMPTY_PAGE = 2;
+    const INVALID_PAGE = 3;
 
     /**
      * Mock a call made to ZendeskSource::processKnowledgeBases().
      *
      * @return array
+     * @throws Exception
      */
     public function processKnowledgeBases(): array
     {
-        $mock = $this->config["mock"];
+        $mock = $this->config["pageFrom"];
         $result = $this->returnMockRecords($mock);
         return $result;
     }
@@ -31,10 +35,11 @@ class ZendeskMockSource extends ZendeskSource
      * Mock a call made to ZendeskSource::processKnowledgeCategories().
      *
      * @return array
+     * @throws Exception
      */
     public function processKnowledgeCategories(): array
     {
-        $mock = $this->config["mock"];
+        $mock = $this->config["pageFrom"];
         $result = $this->returnMockRecords($mock);
         return $result;
     }
@@ -43,10 +48,11 @@ class ZendeskMockSource extends ZendeskSource
      * Mock a call made to ZendeskSource::processKnowledgeArticles.
      *
      * @return array
+     * @throws Exception
      */
     public function processKnowledgeArticles(): array
     {
-        $mock = $this->config["mock"];
+        $mock = $this->config["pageFrom"];
         $result = $this->returnMockRecords($mock);
         return $result;
     }
@@ -59,12 +65,12 @@ class ZendeskMockSource extends ZendeskSource
     protected function returnMockRecords(int $mockValue): array
     {
         switch ($mockValue) {
-            case self::VALID_RESPONSE:
+            case self::VALID_PAGE:
                 return ["zd1", "zd2", "zd3"];
                 break;
-            case self::EMPTY_RESPONSE:
+            case self::EMPTY_PAGE:
                 return [];
-            case self::INVALID_RESPONSE:
+            case self::INVALID_PAGE:
             default:
                 throw new Exception("An error has occurred");
         }

--- a/src/Sources/ZendeskSource.php
+++ b/src/Sources/ZendeskSource.php
@@ -630,10 +630,8 @@ class ZendeskSource extends AbstractSource
      * @param array $row
      * @return string
      */
-    protected function prepareBody(
-        ?string $body = null,
-        array $row = []
-    ): string {
+    protected function prepareBody(array $row, ?string $body = null): string
+    {
         $returnBody = "";
         if (is_string($body)) {
             $returnBody = $this->parseUrls($body);
@@ -1013,7 +1011,7 @@ HTML;
     /**
      * Sync archived ZenDesk content with Vanilla.
      */
-    public function syncUpArchivedZenDeskArticles()
+    private function syncUpArchivedZenDeskArticles()
     {
         $this->logger->info(
             "Delete mode enabled, all other import modes will not run during this process"

--- a/src/Sources/ZendeskSource.php
+++ b/src/Sources/ZendeskSource.php
@@ -630,8 +630,10 @@ class ZendeskSource extends AbstractSource
      * @param array $row
      * @return string
      */
-    protected function prepareBody(array $row, ?string $body = null): string
-    {
+    protected function prepareBody(
+        ?string $body = null,
+        array $row = []
+    ): string {
         $returnBody = "";
         if (is_string($body)) {
             $returnBody = $this->parseUrls($body);

--- a/src/Sources/ZendeskSource.php
+++ b/src/Sources/ZendeskSource.php
@@ -234,8 +234,8 @@ class ZendeskSource extends AbstractSource
                 $knowledgeCategories,
                 $translate
             );
-            foreach ($knowledgeCategories as $knowledgeCategory) {
-                $results[] = $knowledgeCategory["foreignID"];
+            foreach ($categories as $category) {
+                $results[] = $this->addPrefix($category["id"]);
             }
         }
         if ($this->config["import"]["retrySections"] ?? true) {
@@ -328,7 +328,6 @@ class ZendeskSource extends AbstractSource
             $kbArticles = $dest->importKnowledgeArticles($knowledgeArticles);
             $translate = $this->config["import"]["translations"] ?? false;
             foreach ($kbArticles as $kbArticle) {
-                $results[] = $kbArticle["foreignID"];
                 if ($translate) {
                     if (!$kbArticle) {
                         $this->logger->error(
@@ -400,6 +399,10 @@ class ZendeskSource extends AbstractSource
                     ]);
                     $dest->importArticleVotes($kbVotes);
                 }
+            }
+
+            foreach ($articles as $article) {
+                $results[] = $this->addPrefix($article["id"]);
             }
         }
         return $results;
@@ -627,8 +630,10 @@ class ZendeskSource extends AbstractSource
      * @param array $row
      * @return string
      */
-    protected function prepareBody(array $row, ?string $body = null): string
-    {
+    protected function prepareBody(
+        ?string $body = null,
+        array $row = []
+    ): string {
         $returnBody = "";
         if (is_string($body)) {
             $returnBody = $this->parseUrls($body);

--- a/src/Sources/ZendeskSource.php
+++ b/src/Sources/ZendeskSource.php
@@ -1011,7 +1011,7 @@ HTML;
     /**
      * Sync archived ZenDesk content with Vanilla.
      */
-    private function syncUpArchivedZenDeskArticles()
+    public function syncUpArchivedZenDeskArticles()
     {
         $this->logger->info(
             "Delete mode enabled, all other import modes will not run during this process"


### PR DESCRIPTION
# Issue

The new queue doesn't allow for jobs to run for more than ~90 seconds. This means that some refactoring of the KB porter is needed in order to accommodate it. 

# Challenge and Solution

## Import

Very little changes were needed since we can call those one page at the time.

## Sync

This one is a bit all over the place with multiple imbricated for loops. It was deemed easier to just implement new functions than untangle the existing logic. 

This took the form of three new functions, `syncKnowledgeBase()`, `syncKnowledgeCategories`, and `syncArticles`. 

We assume that we already know every IDs that is on Zendesk. 

`syncKnowledgeBase()`: This will fetch every KnowledgeBase on the site and returns the KB that matches the foreignIDs.

`syncKnowledgeCategories`: This will fetch every KnowledgeCategories, compare those with the foreignIDs and archive the ones that do not match. We assume that the request to fetch the KnowledgeCategories will be filtered on the previously obtained KnowledgeBaseID.

`syncArticles`: This will fetch every article, compare those with the foreignIDs, and delete the ones that do not match. We assume that the request to fetch the articles will be filtered on the previously obtained KnowledgeBaseID.

# Changes
* Added functions `syncKnowledgeBase()`, `syncKnowledgeCategories`, and `syncArticles` to sync a vanilla KB with a foreign one.
* Refactored the `getKnowledgeBases`, `getKnowledgeCategories`, `getArticles` to take a query as a param rather than a locale.
* Fix arg order of `prepareBody`.
* Added ZendeskMockSource for testing purposes.
* Added VanillaMockDestination for testing purposes.