### PR TITLE
Fix Vanilla Mock Destination Return values

### DIFF
--- a/src/Destinations/VanillaMockDestination.php
+++ b/src/Destinations/VanillaMockDestination.php
@@ -137,7 +137,7 @@ class VanillaMockDestination extends AbstractDestination
     {
         switch ($mockValue) {
             case self::VALID_PAGE:
-                return [1, 2, 3];
+                return ["fetched" => 3, "vanillaIDs" => [1, 2, 3]];
             case self::EMPTY_PAGE:
                 return [];
             case self::INVALID_PAGE:


### PR DESCRIPTION
# Issue

The Vanilla Mock destination dosen't return the same value as the actual Vanilla Destination.

See: https://github.com/vanilla/knowledge-porter/blob/f6a19c8f20458ac7953cdd096982f4678cffe429/src/Destinations/VanillaDestination.php#L1252