### PR TITLE
Fix a bunch of minor issues that sometime prevents sync // VNLA-5468

### DIFF
--- a/src/Destinations/VanillaDestination.php
+++ b/src/Destinations/VanillaDestination.php
@@ -219,6 +219,7 @@ class VanillaDestination extends AbstractDestination
             $lookup = $row;
             $lookup["recordIDs"] = [$row["recordID"]];
             $existing = $this->vanillaApi->getKnowledgeBaseTranslation($lookup);
+
             $patch = $this->updateFields(
                 $existing,
                 $row,
@@ -1014,11 +1015,13 @@ class VanillaDestination extends AbstractDestination
                 $res = $this->compareFields($existing, $new, $fieldsMap);
                 break;
             case self::UPDATE_MODE_ON_DATE:
-                $existingDate = strtotime($existing[self::DATE_UPDATED]);
-                $newDate = strtotime($new[self::DATE_UPDATED]);
+                if (isset($existing[self::DATE_UPDATED])) {
+                    $existingDate = strtotime($existing[self::DATE_UPDATED]);
+                    $newDate = strtotime($new[self::DATE_UPDATED]);
 
-                if ($existingDate < $newDate) {
-                    $res = $this->resolveUpdateFields($new, $fieldsMap);
+                    if ($existingDate < $newDate) {
+                        $res = $this->resolveUpdateFields($new, $fieldsMap);
+                    }
                 }
 
                 break;

--- a/src/Destinations/VanillaDestination.php
+++ b/src/Destinations/VanillaDestination.php
@@ -1323,7 +1323,7 @@ class VanillaDestination extends AbstractDestination
                 );
 
                 $response = $this->vanillaApi->patch(
-                    "/api/v2/articles/{$article["articleID"]}",
+                    "/api/v2/articles/{$article["articleID"]}/status",
                     ["status" => self::DELETED_STATUS]
                 );
 

--- a/src/HttpClients/RequestThrottleMiddleware.php
+++ b/src/HttpClients/RequestThrottleMiddleware.php
@@ -17,6 +17,8 @@ class RequestThrottleMiddleware
 {
     protected $lastRequestTime = null;
 
+    private $lastRequestMicrotime = false;
+
     /**
      * Make sure at least one second has past between each call.
      *
@@ -27,8 +29,7 @@ class RequestThrottleMiddleware
     public function __invoke(HttpRequest $request, callable $next): HttpResponse
     {
         $minRequestMicroTime = 1000 * 1000;
-        $this->lastRequestMicrotime =
-            $this->lastRequestMicrotime ?? microtime(true);
+        $this->lastRequestMicrotime = $this->lastRequestMicrotime ?? microtime(true);
         $diff = microtime(true) - $this->lastRequestMicrotime;
         if ($diff < $minRequestMicroTime) {
             usleep($minRequestMicroTime - (int) $diff);

--- a/src/Sources/ZendeskSource.php
+++ b/src/Sources/ZendeskSource.php
@@ -29,7 +29,6 @@ class ZendeskSource extends AbstractSource
     const LIMIT = 50;
     const PAGE_START = 1;
     const PAGE_END = 10;
-
     const DEFAULT_SOURCE_LOCALE = "en-us";
     const DEFAULT_LOCALE = "en";
 
@@ -286,7 +285,7 @@ class ZendeskSource extends AbstractSource
             $queryParams = ["page" => $page, "per_page" => $pageLimit];
 
             $syncFrom = $this->config["syncFrom"] ?? null;
-            $syncFrom = strtotime($syncFrom);
+            $syncFrom = !is_null($syncFrom) ? strtotime($syncFrom) : null;
             $currentTime = time();
 
             $syncFrom = $syncFrom >= $currentTime ? false : $syncFrom;


### PR DESCRIPTION
Howdy!
This PR is related to the following issue: https://higherlogic.atlassian.net/browse/VNLA-5468

## Manual Testing

We are testing by running the porter locally, but the destination site is [olivierlamycanuel.vanillademo.com](https://olivierlamycanuel.vanillademo.com/)

### Using the `master` branch

- Make sure that `GDN_article`'s record no.**2456**'s `status` is set to `published`.
- Make sure that `GDN_knowledgeBase`'s record no.**1**'s `countArticles` is larger that expected (39 or more).
- Make sure that the site's config json file has `source.import.delete` set to `true`.
- Launch the import process. I'm using `./bin/knowledge-porter import --config="candycrush.zendesk.json"`. Adapt as needed.
